### PR TITLE
fix: YAML syntax error in release-notes.yml

### DIFF
--- a/.github/scripts/generate-ai-description.mjs
+++ b/.github/scripts/generate-ai-description.mjs
@@ -1,0 +1,55 @@
+// Calls GitHub Models (gpt-4o-mini) to generate a Dutch release note description.
+// Falls back to PR body or title if the API is unavailable.
+// Output is written to /tmp/ai_description.txt
+
+const title  = process.env.PR_TITLE        || '';
+const body   = (process.env.PR_BODY        || '').trim();
+const labels = process.env.PR_LABELS       || '[]';
+const files  = process.env.CHANGED_FILES   || '';
+const token  = process.env.GITHUB_TOKEN    || '';
+
+const prompt = [
+  'Je bent technisch schrijver voor FlightPrep, een Blazor-webapplicatie voor voorbereiding van ballonvluchten.',
+  '',
+  'Genereer een beknopte release note in het Nederlands (max 3 zinnen) voor onderstaande pull request.',
+  'Wees concreet: noem wat er nieuw/gewijzigd is en wat het voordeel is voor de piloot/gebruiker.',
+  'Schrijf ALLEEN de release note tekst, zonder titels, bullet points of opmaak.',
+  '',
+  `PR Titel: ${title}`,
+  `PR Beschrijving: ${body || '(geen)'}`,
+  `Labels: ${labels}`,
+  `Gewijzigde bestanden: ${files || '(onbekend)'}`,
+].join('\n');
+
+let description = body || title;
+
+try {
+  const res = await fetch('https://models.inference.ai.azure.com/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 250,
+      temperature: 0.6,
+    }),
+  });
+
+  if (res.ok) {
+    const data = await res.json();
+    description = data.choices?.[0]?.message?.content?.trim() || description;
+    console.error(`AI generated description (${description.length} chars)`);
+  } else {
+    const err = await res.text();
+    console.error(`GitHub Models API ${res.status} — using fallback. Response: ${err}`);
+  }
+} catch (e) {
+  console.error(`AI call failed: ${e.message} — using fallback`);
+}
+
+const { writeFileSync } = await import('fs');
+writeFileSync('/tmp/ai_description.txt', description);
+console.log('Description written to /tmp/ai_description.txt');

--- a/.github/scripts/update-release-notes.mjs
+++ b/.github/scripts/update-release-notes.mjs
@@ -1,0 +1,47 @@
+// Reads AI description from /tmp/ai_description.txt, bumps the version,
+// and prepends a new entry to src/FlightPrep/wwwroot/release-notes.json.
+
+const { readFileSync, writeFileSync, existsSync } = await import('fs');
+
+const jsonPath = 'src/FlightPrep/wwwroot/release-notes.json';
+const data = JSON.parse(
+  existsSync(jsonPath) ? readFileSync(jsonPath, 'utf8') : '{"currentVersion":"0.0.0","entries":[]}'
+);
+
+const labels   = JSON.parse(process.env.PR_LABELS || '[]');
+const title    = process.env.PR_TITLE  || '';
+const labelStr = labels.join(' ').toLowerCase();
+const aiDesc   = readFileSync('/tmp/ai_description.txt', 'utf8').trim();
+
+// Version bump rules:
+//   [feature] / label feature   → major  (X+1.0.0)
+//   [refactor] / label refactor  → minor  (X.X+1.0)
+//   [BUG] / [fix] / label bug    → patch  (X.X.X+1)
+let bumpType = 'patch';
+if (/\[feature\]/i.test(title) || labelStr.includes('feature') || labelStr.includes('enhancement'))
+  bumpType = 'major';
+else if (/\[refactor\]/i.test(title) || labelStr.includes('refactor'))
+  bumpType = 'minor';
+else if (/\[bug\]/i.test(title) || /\[fix\]/i.test(title) || labelStr.includes('bug') || labelStr.includes('fix'))
+  bumpType = 'patch';
+
+const [maj, min, pat] = (data.currentVersion || '0.0.0').split('.').map(Number);
+const newVersion =
+  bumpType === 'major' ? `${maj + 1}.0.0` :
+  bumpType === 'minor' ? `${maj}.${min + 1}.0` :
+                         `${maj}.${min}.${pat + 1}`;
+
+const entry = {
+  pr:          parseInt(process.env.PR_NUMBER),
+  version:     newVersion,
+  title,
+  description: aiDesc,
+  author:      process.env.PR_AUTHOR || '',
+  labels,
+  date:        process.env.MERGE_DATE || new Date().toISOString(),
+};
+
+data.currentVersion = newVersion;
+data.entries = [entry, ...(data.entries || [])];
+writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
+console.log(`v${newVersion} (${bumpType}) — PR #${entry.pr}: ${title}`);

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  models: read      # GitHub Models API (GPT-4o-mini)
+  models: read
   pull-requests: read
 
 jobs:
@@ -30,70 +30,17 @@ jobs:
             --repo ${{ github.repository }} \
             --json files \
             --jq '[.files[].path] | join(", ")' \
-          | head -c 800)
+            | head -c 800)
           echo "list=$FILES" >> $GITHUB_OUTPUT
 
       - name: Generate AI release note description
-        id: ai
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE:   ${{ github.event.pull_request.title }}
-          PR_BODY:    ${{ github.event.pull_request.body }}
-          PR_LABELS:  ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE:      ${{ github.event.pull_request.title }}
+          PR_BODY:       ${{ github.event.pull_request.body }}
+          PR_LABELS:     ${{ toJson(github.event.pull_request.labels.*.name) }}
           CHANGED_FILES: ${{ steps.files.outputs.list }}
-        run: |
-          node --input-type=module << 'EOF'
-          const title  = process.env.PR_TITLE  || '';
-          const body   = process.env.PR_BODY   || '';
-          const labels = process.env.PR_LABELS || '[]';
-          const files  = process.env.CHANGED_FILES || '';
-          const token  = process.env.GITHUB_TOKEN;
-
-          const prompt = `Je bent technisch schrijver voor FlightPrep, een Blazor-webapplicatie voor voorbereiding van ballonvluchten.
-
-Genereer een beknopte release note in het Nederlands (max 3 zinnen) voor onderstaande pull request.
-Wees concreet: noem wat er nieuw/gewijzigd is en wat het voordeel is voor de piloot/gebruiker.
-Schrijf ALLEEN de release note tekst, zonder titels, bullet points of opmaak.
-
-PR Titel: ${title}
-PR Beschrijving: ${body.trim() || '(geen)'}
-Labels: ${labels}
-Gewijzigde bestanden: ${files || '(onbekend)'}`;
-
-          let description = body.trim() || title; // fallback
-
-          try {
-            const res = await fetch('https://models.inference.ai.azure.com/chat/completions', {
-              method: 'POST',
-              headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-              },
-              body: JSON.stringify({
-                model: 'gpt-4o-mini',
-                messages: [{ role: 'user', content: prompt }],
-                max_tokens: 250,
-                temperature: 0.6
-              })
-            });
-
-            if (res.ok) {
-              const data = await res.json();
-              description = data.choices?.[0]?.message?.content?.trim() || description;
-              console.error(`AI generated: ${description}`);
-            } else {
-              const err = await res.text();
-              console.error(`AI API ${res.status}: ${err} — using PR body as fallback`);
-            }
-          } catch (e) {
-            console.error(`AI call failed: ${e.message} — using PR body as fallback`);
-          }
-
-          // Write to file (avoids shell escaping issues)
-          const fs = await import('fs');
-          fs.writeFileSync('/tmp/ai_description.txt', description);
-          EOF
-          echo "Description written."
+        run: node --input-type=module < .github/scripts/generate-ai-description.mjs
 
       - name: Update release-notes.json
         env:
@@ -102,47 +49,7 @@ Gewijzigde bestanden: ${files || '(onbekend)'}`;
           PR_AUTHOR:  ${{ github.event.pull_request.user.login }}
           PR_LABELS:  ${{ toJson(github.event.pull_request.labels.*.name) }}
           MERGE_DATE: ${{ github.event.pull_request.merged_at }}
-        run: |
-          node --input-type=module << 'EOF'
-          const fs = await import('fs');
-          const path = 'src/FlightPrep/wwwroot/release-notes.json';
-          const data = JSON.parse(fs.existsSync(path) ? fs.readFileSync(path, 'utf8') : '{"currentVersion":"0.0.0","entries":[]}');
-
-          const labels   = JSON.parse(process.env.PR_LABELS || '[]');
-          const title    = process.env.PR_TITLE || '';
-          const labelStr = labels.join(' ').toLowerCase();
-          const aiDesc   = fs.readFileSync('/tmp/ai_description.txt', 'utf8').trim();
-
-          // Version bump: [feature] → major, [refactor] → minor, [BUG]/[fix] → patch
-          let bumpType = 'patch';
-          if (/\[feature\]/i.test(title) || labelStr.includes('feature') || labelStr.includes('enhancement'))
-            bumpType = 'major';
-          else if (/\[refactor\]/i.test(title) || labelStr.includes('refactor'))
-            bumpType = 'minor';
-          else if (/\[bug\]/i.test(title) || /\[fix\]/i.test(title) || labelStr.includes('bug') || labelStr.includes('fix'))
-            bumpType = 'patch';
-
-          const [maj, min, pat] = (data.currentVersion || '0.0.0').split('.').map(Number);
-          const newVersion =
-            bumpType === 'major' ? `${maj+1}.0.0` :
-            bumpType === 'minor' ? `${maj}.${min+1}.0` :
-                                   `${maj}.${min}.${pat+1}`;
-
-          const entry = {
-            pr:          parseInt(process.env.PR_NUMBER),
-            version:     newVersion,
-            title,
-            description: aiDesc,
-            author:      process.env.PR_AUTHOR || '',
-            labels,
-            date:        process.env.MERGE_DATE || new Date().toISOString()
-          };
-
-          data.currentVersion = newVersion;
-          data.entries = [entry, ...(data.entries || [])];
-          fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
-          console.log(`v${newVersion} (${bumpType}) — PR #${entry.pr}: ${title}`);
-          EOF
+        run: node --input-type=module < .github/scripts/update-release-notes.mjs
 
       - name: Commit release notes
         run: |


### PR DESCRIPTION
Probleem: multiline JS template literal in inline heredoc had regels op kolom 0, waardoor de YAML-parser het run-blok vroegtijdig afsloot.

Oplossing: JS-logica verplaatst naar aparte scriptbestanden:
  .github/scripts/generate-ai-description.mjs
  .github/scripts/update-release-notes.mjs

Workflow roept scripts aan via 'node --input-type=module < script.mjs' Geen inline JS meer in de YAML, geen escaping-problemen.