### PR TITLE
fix: voeg permissions toe aan build job in ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # git push release-notes.json
+      models: read           # GitHub Models API (gpt-4o-mini)
+      pull-requests: read    # gh api .../pulls/...
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- contents: write  → git push release-notes.json naar main
- models: read     → GitHub Models API (gpt-4o-mini) voor AI beschrijving
- pull-requests: read → gh api voor PR-info ophalen