### PR TITLE
Fix text changes

### DIFF
--- a/src/FlightPrep.Domain.Tests/LiftCalculatorTests.cs
+++ b/src/FlightPrep.Domain.Tests/LiftCalculatorTests.cs
@@ -4,7 +4,7 @@ namespace FlightPrep.Domain.Tests;
 
 /// <summary>
 /// Unit tests for <see cref="LiftCalculator.Calculate"/>.
-/// Covers the ISA-based total lift formula from the Belgian Hot Air Balloon
+/// Covers the ISA-based total lift formula from the Hot Air Balloon
 /// Flight Manual, Amendment 18, Appendix 2, Page A2-1.
 /// All expected values are pre-computed from the published formula.
 /// </summary>

--- a/src/FlightPrep.Domain/Services/LiftCalculator.cs
+++ b/src/FlightPrep.Domain/Services/LiftCalculator.cs
@@ -1,7 +1,7 @@
 namespace FlightPrep.Services;
 
 /// <summary>
-/// ISA-based total lift formula — Belgian Hot Air Balloon Flight Manual,
+/// ISA-based total lift formula — Cameron Hot Air Balloon Flight Manual,
 /// Amendment 18, Appendix 2, Page A2-1.
 /// </summary>
 public static class LiftCalculator

--- a/src/FlightPrep.Infrastructure/Services/PdfService.cs
+++ b/src/FlightPrep.Infrastructure/Services/PdfService.cs
@@ -223,7 +223,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                             .Text($"ISA Ta @ max alt: {lr.AmbientTempAtAltC:F1}°C  |  ISA P @ max alt: {lr.PressureHpa:F1} hPa");
 
                         col.Item().Background(Colors.White).Padding(3)
-                            .Text("Berekend via ISA-formule (Bijlage 2, Belgian Hot Air Balloon Flight Manual, Cameron Balloons Ltd.)")
+                            .Text("Berekend via ISA-formule (Bijlage 2, Hot Air Balloon Flight Manual, Cameron Balloons Ltd.)")
                             .FontSize(7).Italic().FontColor(Colors.Grey.Darken1);
                     }
 

--- a/src/FlightPrep/Components/FlightPassengerList.razor
+++ b/src/FlightPrep/Components/FlightPassengerList.razor
@@ -64,7 +64,7 @@
                 Stap 3 — L = 0,3484 × @_V.ToString("F0") × @_liftResult.PressureHpa.ToString("F1") × (1/(Ta+273,15) − 1/(@_Ti.ToString("F0")+273,15)) = @_liftResult.TotalLiftKg.ToString("F1") kg
             </small>
             <small class="text-muted fst-italic d-block mt-1">
-                ¹ Formule: Belgian Hot Air Balloon Flight Manual, Amendment 18, Appendix 2, p. A2-1 (Cameron Balloons Ltd.)
+                ¹ Formule: Hot Air Balloon Flight Manual, Amendment 18, Appendix 2, p. A2-1 (Cameron Balloons Ltd.)
             </small>
         </div>
     </div>
@@ -191,7 +191,7 @@
         Fp.MaxAltitudeFt * 0.3048 > Fp.Location!.ElevationM;
 
     /// <summary>
-    /// Calculates total lift using the ISA formula (Belgian Flight Manual, Appendix 2)
+    /// Calculates total lift using the ISA formula (Cameron Flight Manual, Appendix 2)
     /// and writes the result to Fp.TotaalLiftKg.
     /// </summary>
     private void BerekenLift()


### PR DESCRIPTION
This pull request updates references throughout the codebase to correctly attribute the ISA-based total lift formula to the "Hot Air Balloon Flight Manual, Cameron Balloons Ltd." instead of the previously referenced Belgian manual. This ensures documentation and user-facing text are accurate and consistent.

Documentation and attribution updates:

* Updated XML documentation in `LiftCalculator.cs` and `LiftCalculatorTests.cs` to reference the "Cameron Hot Air Balloon Flight Manual" as the source of the ISA-based total lift formula. [[1]](diffhunk://#diff-45e60fbe103445bbe06fb6cb46339a07b82b5d23ca7a0495fb889537ec1b4953L4-R4) [[2]](diffhunk://#diff-052ea23325a001e294bfa8b4514c881d90246131d069f0c2152d9338ef62aa58L7-R7)
* Revised user-facing text and comments in `FlightPassengerList.razor` and `PdfService.cs` to attribute the formula to the correct manual and company. [[1]](diffhunk://#diff-7aec4353c65a8c764def0b27f8afec1b5ec66380b94736757c65320a6818971cL67-R67) [[2]](diffhunk://#diff-7aec4353c65a8c764def0b27f8afec1b5ec66380b94736757c65320a6818971cL194-R194) [[3]](diffhunk://#diff-5c12984cab06ae324502c89e41f205bc5895c02e9f9221f25712b11b33586afaL226-R226)