### PR TITLE
fix: wire Serilog to Application Insights sink (#45)

### DIFF
--- a/src/FlightPrep/FlightPrep.csproj
+++ b/src/FlightPrep/FlightPrep.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 

--- a/src/FlightPrep/Program.cs
+++ b/src/FlightPrep/Program.cs
@@ -1,10 +1,12 @@
 using FlightPrep.Components;
 using FlightPrep.Data;
 using FlightPrep.Services;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.EntityFrameworkCore;
 using QuestPDF;
 using QuestPDF.Infrastructure;
 using Serilog;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 
 Settings.License = LicenseType.Community;
 
@@ -14,9 +16,17 @@ Log.Logger = new LoggerConfiguration()
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseSerilog((ctx, cfg) => cfg
-    .ReadFrom.Configuration(ctx.Configuration)
-    .WriteTo.Console());
+builder.Host.UseSerilog((ctx, cfg) =>
+{
+    cfg.ReadFrom.Configuration(ctx.Configuration)
+       .WriteTo.Console();
+
+    var connStr = ctx.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+    if (!string.IsNullOrEmpty(connStr))
+        cfg.WriteTo.ApplicationInsights(
+            new TelemetryConfiguration { ConnectionString = connStr },
+            TelemetryConverter.Traces);
+});
 
 builder.Services.AddDbContextFactory<AppDbContext>(opts =>
     opts.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));


### PR DESCRIPTION
This pull request adds Application Insights telemetry support to the `FlightPrep` project by integrating the `Serilog.Sinks.ApplicationInsights` package and configuring Serilog to send logs to Application Insights when a connection string is provided. The changes ensure that telemetry is only enabled if the relevant configuration is present.

**Telemetry integration:**

* Added `Serilog.Sinks.ApplicationInsights` package to the project dependencies in `FlightPrep.csproj`.
* Updated Serilog configuration in `Program.cs` to write logs to Application Insights using the connection string from configuration, and only enable this sink if the string is present.
* Added necessary `using` statements for Application Insights and telemetry converters in `Program.cs`.