### PR TITLE
fix: use TelemetryClient overload to avoid TelemetryConfiguration.Act…

### DIFF
--- a/src/FlightPrep/Program.cs
+++ b/src/FlightPrep/Program.cs
@@ -1,6 +1,7 @@
 using FlightPrep.Components;
 using FlightPrep.Data;
 using FlightPrep.Services;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.EntityFrameworkCore;
 using QuestPDF;
@@ -23,9 +24,11 @@ builder.Host.UseSerilog((ctx, cfg) =>
 
     var connStr = ctx.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
     if (!string.IsNullOrEmpty(connStr))
-        cfg.WriteTo.ApplicationInsights(
-            new TelemetryConfiguration { ConnectionString = connStr },
-            TelemetryConverter.Traces);
+    {
+        var telemetryClient = new TelemetryClient(
+            new TelemetryConfiguration { ConnectionString = connStr });
+        cfg.WriteTo.ApplicationInsights(telemetryClient, TelemetryConverter.Traces);
+    }
 });
 
 builder.Services.AddDbContextFactory<AppDbContext>(opts =>


### PR DESCRIPTION
…ive crash on Azure (#45)

TelemetryConfiguration overload internally calls the deprecated static TelemetryConfiguration.Active property which is absent from the DLL version loaded by the Azure App Service AI Agent extension, causing a MissingMethodException at startup.

Switching to the TelemetryClient overload avoids that code path entirely.