### PR TITLE
fix: correct CI/CD deploy job env scope, login guard, and az output (…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -219,12 +219,34 @@ jobs:
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push'
     environment: production
+    env:
+      AI_CONN_STR: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+    # Required GitHub Actions secrets for this job:
+    # - AZURE_PUBLISH_PROFILE      : App Service publish profile (XML)
+    # - AZURE_CREDENTIALS          : Service principal JSON for az login
+    #                                (az ad sp create-for-rbac --sdk-auth)
+    # - APPLICATIONINSIGHTS_CONNECTION_STRING : from Azure Portal → App Insights → Overview
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: flightprep-publish
           path: ./publish
+
+      - name: Azure Login
+        if: env.AI_CONN_STR != ''
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Configure App Insights connection string
+        if: env.AI_CONN_STR != ''
+        run: |
+          az webapp config appsettings set \
+            --name flightprep-web \
+            --resource-group flightprep-rg \
+            --settings APPLICATIONINSIGHTS_CONNECTION_STRING="$AI_CONN_STR" \
+            --output none
 
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
…#48)

- Move AI_CONN_STR to job-level env so if: condition evaluates correctly
- Guard azure/login step with same if condition to prevent deploy regression
- Add --output none to az appsettings set to suppress secret values in logs