### PR TITLE
fix: pass APPLICATIONINSIGHTS_CONNECTION_STRING through Docker Compose (#47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in your values.
+# .env is gitignored — never commit real secrets.
+
+# PostgreSQL credentials (used by docker-compose.yml)
+POSTGRES_DB=flightprep
+POSTGRES_USER=fpuser
+POSTGRES_PASSWORD=fppass
+
+# Application Insights connection string (optional — leave empty to disable monitoring locally)
+# Find it in Azure Portal → Application Insights resource → Overview → Connection String
+APPLICATIONINSIGHTS_CONNECTION_STRING=

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ packages/
 # Secrets
 *secrets*
 appsettings.Local.json
+.env
 
 # Publish
 publish/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=flightprep;Username=${POSTGRES_USER:-fpuser};Password=${POSTGRES_PASSWORD:-fppass}
+      - APPLICATIONINSIGHTS_CONNECTION_STRING=${APPLICATIONINSIGHTS_CONNECTION_STRING:-}
     volumes:
       - dpkeys:/root/.aspnet/DataProtection-Keys
     depends_on:


### PR DESCRIPTION


- docker-compose.yml: forward APPLICATIONINSIGHTS_CONNECTION_STRING from host env / .env file (empty default = graceful no-op, matches Program.cs guard)
- .gitignore: add .env to prevent accidental secret commits
- .env.example: document all available env vars for local development