### PR TITLE
feat: add FlightTelemetryInitializer to enrich App Insights telemetry with flight context

### DIFF
--- a/src/FlightPrep/Program.cs
+++ b/src/FlightPrep/Program.cs
@@ -1,8 +1,11 @@
 using FlightPrep.Components;
 using FlightPrep.Data;
 using FlightPrep.Services;
+using FlightPrep.Telemetry;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Microsoft.EntityFrameworkCore;
 using QuestPDF;
 using QuestPDF.Infrastructure;
@@ -45,6 +48,11 @@ builder.Services.AddScoped<IFlightPreparationService, FlightPreparationService>(
 // Application Insights — only active when APPLICATIONINSIGHTS_CONNECTION_STRING is set
 if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
     builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<FlightTelemetryInitializer>();
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddProcessor(
+        sp => sp.GetRequiredService<FlightTelemetryInitializer>()));
 builder.Services.AddSingleton<IKmlService, KmlService>();
 builder.Services.AddSingleton<ITrajectoryService, TrajectoryService>();
 builder.Services.AddScoped<IEnhancedTrajectoryService, EnhancedTrajectoryService>();

--- a/src/FlightPrep/Telemetry/FlightTelemetryInitializer.cs
+++ b/src/FlightPrep/Telemetry/FlightTelemetryInitializer.cs
@@ -1,0 +1,37 @@
+using OpenTelemetry;
+using System.Diagnostics;
+
+namespace FlightPrep.Telemetry;
+
+/// <summary>
+/// OpenTelemetry processor that enriches every trace span with flight and pilot context.
+/// Runs at HTTP level only — Blazor circuit messages do not carry an HttpContext.
+/// </summary>
+public sealed class FlightTelemetryInitializer : BaseProcessor<Activity>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public FlightTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public override void OnStart(Activity data)
+    {
+        var ctx = _httpContextAccessor.HttpContext;
+        if (ctx is null) return;
+
+        // Tag authenticated pilot identity (forward-compatible — auth not yet implemented)
+        if (ctx.User.Identity?.IsAuthenticated == true)
+            data.SetTag("enduser.id", ctx.User.Identity.Name);
+
+        // Enrich with flight ID from route when on a flight detail/edit page
+        // Route parameter is named "Id" for /flights/{Id:int} and /flights/{Id:int}/edit
+        if (ctx.Request.RouteValues.TryGetValue("Id", out var flightId)
+            && flightId is not null)
+        {
+            data.SetTag("flightId", flightId.ToString()!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #49

Adds a custom OpenTelemetry processor that enriches every Application Insights telemetry item with domain context, making it easier to correlate errors and slow requests back to a specific flight or pilot in Azure Monitor.

## Changes

- **New:** `src/FlightPrep/Telemetry/FlightTelemetryInitializer.cs` — `BaseProcessor<Activity>` that sets:
  - `enduser.id` tag when a user is authenticated (forward-compatible — auth not yet implemented)
  - `flightId` tag from route parameter `Id` on `/flights/{Id:int}` pages
- **Modified:** `src/FlightPrep/Program.cs` — registers `IHttpContextAccessor` and the processor into the OTel pipeline

## Technical notes

- `ITelemetryInitializer` no longer exists in `Microsoft.ApplicationInsights.AspNetCore` v3.0.0 (fully rewritten on OpenTelemetry). `BaseProcessor<Activity>` is the correct equivalent.
- No new NuGet packages required — all OTel types are transitive dependencies of the existing `Microsoft.ApplicationInsights.AspNetCore` package.
- The enricher is a no-op when `HttpContext` is null (Blazor circuit messages, background tasks) — correct and expected for Blazor Server.

## 🟡 Known non-blocking issues (flagged by review agent)

1. OTel processor is registered unconditionally — minor CPU waste in local dev with no connection string. Safe to address in a follow-up.
2. `Identity.Name` could theoretically be null even when `IsAuthenticated == true` — no crash risk, only a silent empty tag. Will be properly handled when auth (#44) lands.

## Review result

✅ No 🔴 issues. Safe to merge.