### PR TITLE
fix: service layer for settings pages + migrate via CI/CD (#26, #30) [fix]

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -231,19 +231,26 @@ jobs:
     # Note: APPLICATIONINSIGHTS_CONNECTION_STRING is managed by Bicep (infra/main.bicep)
     #       and does not need to be injected here.
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
-          name: flightprep-publish
-          path: ./publish
+          dotnet-version: '10.0.x'
 
       - name: Run EF Core migrations
         run: |
           dotnet tool install --global dotnet-ef --version 9.0.5 || true
           dotnet ef database update \
-            --project src/FlightPrep/FlightPrep.csproj \
-            --no-build \
+            --project src/FlightPrep.Infrastructure/FlightPrep.Infrastructure.csproj \
+            --startup-project src/FlightPrep/FlightPrep.csproj \
             --connection "${{ secrets.AZURE_POSTGRESQL_CONNECTION_STRING }}"
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: flightprep-publish
+          path: ./publish
 
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -240,7 +240,8 @@ jobs:
 
       - name: Run EF Core migrations
         run: |
-          dotnet tool install --global dotnet-ef --version 9.0.5 || true
+          dotnet tool install --global dotnet-ef --version 9.0.5 \
+            || dotnet tool update --global dotnet-ef --version 9.0.5
           dotnet ef database update \
             --project src/FlightPrep.Infrastructure/FlightPrep.Infrastructure.csproj \
             --startup-project src/FlightPrep/FlightPrep.csproj \

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,6 +237,14 @@ jobs:
           name: flightprep-publish
           path: ./publish
 
+      - name: Run EF Core migrations
+        run: |
+          dotnet tool install --global dotnet-ef --version 9.0.5 || true
+          dotnet ef database update \
+            --project src/FlightPrep/FlightPrep.csproj \
+            --no-build \
+            --connection "${{ secrets.AZURE_POSTGRESQL_CONNECTION_STRING }}"
+
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3
         with:

--- a/.idea/.idea.FlightPrep/.idea/.name
+++ b/.idea/.idea.FlightPrep/.idea/.name
@@ -1,0 +1,1 @@
+FlightPrep

--- a/.idea/.idea.FlightPrep/.idea/indexLayout.xml
+++ b/.idea/.idea.FlightPrep/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.FlightPrep/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/.idea.FlightPrep/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,21 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="7">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+            <item index="6" class="java.lang.String" itemvalue="width" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/.idea.FlightPrep/.idea/vcs.xml
+++ b/.idea/.idea.FlightPrep/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/FlightPrep.Domain/Services/IBalloonService.cs
+++ b/src/FlightPrep.Domain/Services/IBalloonService.cs
@@ -1,0 +1,22 @@
+using FlightPrep.Domain.Models;
+
+namespace FlightPrep.Domain.Services;
+
+/// <summary>
+///     Encapsulates all persistence operations for <see cref="Balloon" /> entities.
+///     Pages must not access <c>IDbContextFactory</c> directly.
+/// </summary>
+public interface IBalloonService
+{
+    /// <summary>Returns all balloons visible to the caller, ordered by registration.</summary>
+    Task<List<Balloon>> GetAllAsync(string? userId, bool isAdmin);
+
+    /// <summary>Updates an existing balloon. Ownership is enforced unless caller is admin.</summary>
+    Task UpdateAsync(Balloon editBalloon, string? userId, bool isAdmin);
+
+    /// <summary>Adds a new balloon owned by <paramref name="userId" />.</summary>
+    Task AddAsync(Balloon newBalloon, string? userId);
+
+    /// <summary>Deletes a balloon by id. Ownership is enforced unless caller is admin.</summary>
+    Task DeleteAsync(int id, string? userId, bool isAdmin);
+}

--- a/src/FlightPrep.Domain/Services/ILocationService.cs
+++ b/src/FlightPrep.Domain/Services/ILocationService.cs
@@ -1,0 +1,22 @@
+using FlightPrep.Domain.Models;
+
+namespace FlightPrep.Domain.Services;
+
+/// <summary>
+///     Encapsulates all persistence operations for <see cref="Location" /> entities.
+///     Pages must not access <c>IDbContextFactory</c> directly.
+/// </summary>
+public interface ILocationService
+{
+    /// <summary>Returns all locations visible to the caller, ordered by name.</summary>
+    Task<List<Location>> GetAllAsync(string? userId, bool isAdmin);
+
+    /// <summary>Updates an existing location. Ownership is enforced unless caller is admin.</summary>
+    Task UpdateAsync(Location editLoc, string? userId, bool isAdmin);
+
+    /// <summary>Adds a new location owned by <paramref name="userId" />.</summary>
+    Task AddAsync(Location newLoc, string? userId);
+
+    /// <summary>Deletes a location by id. Ownership is enforced unless caller is admin.</summary>
+    Task DeleteAsync(int id, string? userId, bool isAdmin);
+}

--- a/src/FlightPrep.Domain/Services/IPilotService.cs
+++ b/src/FlightPrep.Domain/Services/IPilotService.cs
@@ -1,0 +1,22 @@
+using FlightPrep.Domain.Models;
+
+namespace FlightPrep.Domain.Services;
+
+/// <summary>
+///     Encapsulates all persistence operations for <see cref="Pilot" /> entities.
+///     Pages must not access <c>IDbContextFactory</c> directly.
+/// </summary>
+public interface IPilotService
+{
+    /// <summary>Returns all pilots visible to the caller, ordered by name.</summary>
+    Task<List<Pilot>> GetAllAsync(string? userId, bool isAdmin);
+
+    /// <summary>Updates an existing pilot. Ownership is enforced unless caller is admin.</summary>
+    Task UpdateAsync(Pilot editPilot, string? userId, bool isAdmin);
+
+    /// <summary>Adds a new pilot owned by <paramref name="userId" />.</summary>
+    Task AddAsync(Pilot newPilot, string? userId);
+
+    /// <summary>Deletes a pilot by id. Ownership is enforced unless caller is admin.</summary>
+    Task DeleteAsync(int id, string? userId, bool isAdmin);
+}

--- a/src/FlightPrep.Tests/BalloonServiceTests.cs
+++ b/src/FlightPrep.Tests/BalloonServiceTests.cs
@@ -1,0 +1,232 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Infrastructure.Data;
+using FlightPrep.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FlightPrep.Tests;
+
+/// <summary>
+///     Integration tests for <see cref="BalloonService" /> using the EF Core in-memory provider.
+///     Each test gets a unique named database to ensure full isolation.
+/// </summary>
+public class BalloonServiceTests
+{
+    // ── Factory helpers ───────────────────────────────────────────────────────
+
+    private static IDbContextFactory<AppDbContext> CreateFactory(string dbName)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o =>
+            o.UseInMemoryDatabase(dbName)
+             .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+        return services.BuildServiceProvider()
+            .GetRequiredService<IDbContextFactory<AppDbContext>>();
+    }
+
+    private static BalloonService BuildSut(IDbContextFactory<AppDbContext> factory)
+        => new(factory, NullLogger<BalloonService>.Instance);
+
+    private static async Task SeedBalloonsAsync(IDbContextFactory<AppDbContext> factory, IEnumerable<Balloon> balloons)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        db.Balloons.AddRange(balloons);
+        await db.SaveChangesAsync();
+    }
+
+    // ── GetAllAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllAsync_AdminUser_ReturnsAllBalloons()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_AdminUser_ReturnsAllBalloons));
+        await SeedBalloonsAsync(factory, [
+            new Balloon { Registration = "OO-A01", Type = "BB20", OwnerId = "user-1" },
+            new Balloon { Registration = "OO-B02", Type = "BB30", OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: true);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NonAdminUser_ReturnsOnlyOwnBalloons()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NonAdminUser_ReturnsOnlyOwnBalloons));
+        await SeedBalloonsAsync(factory, [
+            new Balloon { Registration = "OO-A01", Type = "BB20", OwnerId = "user-1" },
+            new Balloon { Registration = "OO-B02", Type = "BB30", OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: false);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("OO-A01", result[0].Registration);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NullUserId_ReturnsEmpty()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NullUserId_ReturnsEmpty));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-A01", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: null, isAdmin: false);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ── AddAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_ValidUser_AddsBalloonWithOwnerId()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_ValidUser_AddsBalloonWithOwnerId));
+        var sut = BuildSut(factory);
+        var balloon = new Balloon { Registration = "OO-NEW", Type = "BB25" };
+
+        // Act
+        await sut.AddAsync(balloon, "user-42");
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        var saved = await db.Balloons.SingleAsync();
+        Assert.Equal("OO-NEW", saved.Registration);
+        Assert.Equal("user-42", saved.OwnerId);
+    }
+
+    [Fact]
+    public async Task AddAsync_NullUserId_DoesNotInsert()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_NullUserId_DoesNotInsert));
+        var sut = BuildSut(factory);
+
+        // Act
+        await sut.AddAsync(new Balloon { Registration = "OO-GHOST", Type = "BB20" }, userId: null);
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        Assert.Empty(db.Balloons);
+    }
+
+    // ── UpdateAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_Owner_UpdatesBalloon()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_Owner_UpdatesBalloon));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-OLD", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Balloons.SingleAsync();
+        var edit = new Balloon { Id = existing.Id, Registration = "OO-NEW", Type = "BB30", OwnerId = "user-1" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var updated = await db2.Balloons.FindAsync(existing.Id);
+        Assert.Equal("OO-NEW", updated!.Registration);
+        Assert.Equal("BB30", updated.Type);
+        Assert.Equal("user-1", updated.OwnerId); // OwnerId must not change
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NonOwner_DoesNotUpdateBalloon()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_NonOwner_DoesNotUpdateBalloon));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-OLD", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Balloons.SingleAsync();
+        var edit = new Balloon { Id = existing.Id, Registration = "OO-HACKED", Type = "BB99", OwnerId = "user-2" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var unchanged = await db2.Balloons.FindAsync(existing.Id);
+        Assert.Equal("OO-OLD", unchanged!.Registration);
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_Owner_DeletesBalloon()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_Owner_DeletesBalloon));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-DEL", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Balloons.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Balloons);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonOwner_DoesNotDeleteBalloon()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_NonOwner_DoesNotDeleteBalloon));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-KEEP", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Balloons.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Single(db2.Balloons);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_AdminUser_DeletesAnyBalloon()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_AdminUser_DeletesAnyBalloon));
+        await SeedBalloonsAsync(factory, [new Balloon { Registration = "OO-ADM", Type = "BB20", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Balloons.SingleAsync()).Id;
+
+        // Act — admin with a different userId
+        await sut.DeleteAsync(id, "admin-99", isAdmin: true);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Balloons);
+    }
+}

--- a/src/FlightPrep.Tests/LocationServiceTests.cs
+++ b/src/FlightPrep.Tests/LocationServiceTests.cs
@@ -1,0 +1,231 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Infrastructure.Data;
+using FlightPrep.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FlightPrep.Tests;
+
+/// <summary>
+///     Integration tests for <see cref="LocationService" /> using the EF Core in-memory provider.
+///     Each test gets a unique named database to ensure full isolation.
+/// </summary>
+public class LocationServiceTests
+{
+    // ── Factory helpers ───────────────────────────────────────────────────────
+
+    private static IDbContextFactory<AppDbContext> CreateFactory(string dbName)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o =>
+            o.UseInMemoryDatabase(dbName)
+             .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+        return services.BuildServiceProvider()
+            .GetRequiredService<IDbContextFactory<AppDbContext>>();
+    }
+
+    private static LocationService BuildSut(IDbContextFactory<AppDbContext> factory)
+        => new(factory, NullLogger<LocationService>.Instance);
+
+    private static async Task SeedLocationsAsync(IDbContextFactory<AppDbContext> factory, IEnumerable<Location> locations)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        db.Locations.AddRange(locations);
+        await db.SaveChangesAsync();
+    }
+
+    // ── GetAllAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllAsync_AdminUser_ReturnsAllLocations()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_AdminUser_ReturnsAllLocations));
+        await SeedLocationsAsync(factory, [
+            new Location { Name = "Hasselt", OwnerId = "user-1" },
+            new Location { Name = "Genk",    OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: true);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NonAdminUser_ReturnsOnlyOwnLocations()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NonAdminUser_ReturnsOnlyOwnLocations));
+        await SeedLocationsAsync(factory, [
+            new Location { Name = "Hasselt", OwnerId = "user-1" },
+            new Location { Name = "Genk",    OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: false);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Hasselt", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NullUserId_ReturnsEmpty()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NullUserId_ReturnsEmpty));
+        await SeedLocationsAsync(factory, [new Location { Name = "Hasselt", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: null, isAdmin: false);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ── AddAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_ValidUser_AddsLocationWithOwnerId()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_ValidUser_AddsLocationWithOwnerId));
+        var sut = BuildSut(factory);
+        var location = new Location { Name = "Bruges" };
+
+        // Act
+        await sut.AddAsync(location, "user-42");
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        var saved = await db.Locations.SingleAsync();
+        Assert.Equal("Bruges", saved.Name);
+        Assert.Equal("user-42", saved.OwnerId);
+    }
+
+    [Fact]
+    public async Task AddAsync_NullUserId_DoesNotInsert()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_NullUserId_DoesNotInsert));
+        var sut = BuildSut(factory);
+
+        // Act
+        await sut.AddAsync(new Location { Name = "Ghost Town" }, userId: null);
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        Assert.Empty(db.Locations);
+    }
+
+    // ── UpdateAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_Owner_UpdatesLocation()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_Owner_UpdatesLocation));
+        await SeedLocationsAsync(factory, [new Location { Name = "OldName", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Locations.SingleAsync();
+        var edit = new Location { Id = existing.Id, Name = "NewName", OwnerId = "user-1" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var updated = await db2.Locations.FindAsync(existing.Id);
+        Assert.Equal("NewName", updated!.Name);
+        Assert.Equal("user-1", updated.OwnerId); // OwnerId must not change
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NonOwner_DoesNotUpdateLocation()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_NonOwner_DoesNotUpdateLocation));
+        await SeedLocationsAsync(factory, [new Location { Name = "OldName", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Locations.SingleAsync();
+        var edit = new Location { Id = existing.Id, Name = "HackedName", OwnerId = "user-2" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var unchanged = await db2.Locations.FindAsync(existing.Id);
+        Assert.Equal("OldName", unchanged!.Name);
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_Owner_DeletesLocation()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_Owner_DeletesLocation));
+        await SeedLocationsAsync(factory, [new Location { Name = "ToDelete", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Locations.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Locations);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonOwner_DoesNotDeleteLocation()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_NonOwner_DoesNotDeleteLocation));
+        await SeedLocationsAsync(factory, [new Location { Name = "ToKeep", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Locations.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Single(db2.Locations);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_AdminUser_DeletesAnyLocation()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_AdminUser_DeletesAnyLocation));
+        await SeedLocationsAsync(factory, [new Location { Name = "AdminTarget", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Locations.SingleAsync()).Id;
+
+        // Act — admin with a different userId
+        await sut.DeleteAsync(id, "admin-99", isAdmin: true);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Locations);
+    }
+}

--- a/src/FlightPrep.Tests/PilotServiceTests.cs
+++ b/src/FlightPrep.Tests/PilotServiceTests.cs
@@ -1,0 +1,232 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Infrastructure.Data;
+using FlightPrep.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FlightPrep.Tests;
+
+/// <summary>
+///     Integration tests for <see cref="PilotService" /> using the EF Core in-memory provider.
+///     Each test gets a unique named database to ensure full isolation.
+/// </summary>
+public class PilotServiceTests
+{
+    // ── Factory helpers ───────────────────────────────────────────────────────
+
+    private static IDbContextFactory<AppDbContext> CreateFactory(string dbName)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o =>
+            o.UseInMemoryDatabase(dbName)
+             .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
+        return services.BuildServiceProvider()
+            .GetRequiredService<IDbContextFactory<AppDbContext>>();
+    }
+
+    private static PilotService BuildSut(IDbContextFactory<AppDbContext> factory)
+        => new(factory, NullLogger<PilotService>.Instance);
+
+    private static async Task SeedPilotsAsync(IDbContextFactory<AppDbContext> factory, IEnumerable<Pilot> pilots)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        db.Pilots.AddRange(pilots);
+        await db.SaveChangesAsync();
+    }
+
+    // ── GetAllAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllAsync_AdminUser_ReturnsAllPilots()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_AdminUser_ReturnsAllPilots));
+        await SeedPilotsAsync(factory, [
+            new Pilot { Name = "Alice", OwnerId = "user-1" },
+            new Pilot { Name = "Bob",   OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: true);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NonAdminUser_ReturnsOnlyOwnPilots()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NonAdminUser_ReturnsOnlyOwnPilots));
+        await SeedPilotsAsync(factory, [
+            new Pilot { Name = "Alice", OwnerId = "user-1" },
+            new Pilot { Name = "Bob",   OwnerId = "user-2" }
+        ]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: "user-1", isAdmin: false);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Alice", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NullUserId_ReturnsEmpty()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(GetAllAsync_NullUserId_ReturnsEmpty));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Alice", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        // Act
+        var result = await sut.GetAllAsync(userId: null, isAdmin: false);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ── AddAsync ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_ValidUser_AddsPilotWithOwnerId()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_ValidUser_AddsPilotWithOwnerId));
+        var sut = BuildSut(factory);
+        var pilot = new Pilot { Name = "Charlie" };
+
+        // Act
+        await sut.AddAsync(pilot, "user-42");
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        var saved = await db.Pilots.SingleAsync();
+        Assert.Equal("Charlie", saved.Name);
+        Assert.Equal("user-42", saved.OwnerId);
+    }
+
+    [Fact]
+    public async Task AddAsync_NullUserId_DoesNotInsert()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(AddAsync_NullUserId_DoesNotInsert));
+        var sut = BuildSut(factory);
+
+        // Act
+        await sut.AddAsync(new Pilot { Name = "Ghost" }, userId: null);
+
+        // Assert
+        await using var db = await factory.CreateDbContextAsync();
+        Assert.Empty(db.Pilots);
+    }
+
+    // ── UpdateAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_Owner_UpdatesPilot()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_Owner_UpdatesPilot));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Original", WeightKg = 70, OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Pilots.SingleAsync();
+        var edit = new Pilot { Id = existing.Id, Name = "Updated", WeightKg = 80, OwnerId = "user-1" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var updated = await db2.Pilots.FindAsync(existing.Id);
+        Assert.Equal("Updated", updated!.Name);
+        Assert.Equal(80, updated.WeightKg);
+        Assert.Equal("user-1", updated.OwnerId); // OwnerId must not change
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NonOwner_DoesNotUpdatePilot()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(UpdateAsync_NonOwner_DoesNotUpdatePilot));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Original", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var existing = await db.Pilots.SingleAsync();
+        var edit = new Pilot { Id = existing.Id, Name = "Hacked", OwnerId = "user-2" };
+
+        // Act
+        await sut.UpdateAsync(edit, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        var unchanged = await db2.Pilots.FindAsync(existing.Id);
+        Assert.Equal("Original", unchanged!.Name);
+    }
+
+    // ── DeleteAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_Owner_DeletesPilot()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_Owner_DeletesPilot));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Alice", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Pilots.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-1", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Pilots);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonOwner_DoesNotDeletePilot()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_NonOwner_DoesNotDeletePilot));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Alice", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Pilots.SingleAsync()).Id;
+
+        // Act
+        await sut.DeleteAsync(id, "user-2", isAdmin: false);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Single(db2.Pilots);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_AdminUser_DeletesAnyPilot()
+    {
+        // Arrange
+        var factory = CreateFactory(nameof(DeleteAsync_AdminUser_DeletesAnyPilot));
+        await SeedPilotsAsync(factory, [new Pilot { Name = "Alice", OwnerId = "user-1" }]);
+        var sut = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var id = (await db.Pilots.SingleAsync()).Id;
+
+        // Act — admin with a different userId
+        await sut.DeleteAsync(id, "admin-99", isAdmin: true);
+
+        // Assert
+        await using var db2 = await factory.CreateDbContextAsync();
+        Assert.Empty(db2.Pilots);
+    }
+}

--- a/src/FlightPrep/Components/Pages/Settings/BalloonSettings.razor
+++ b/src/FlightPrep/Components/Pages/Settings/BalloonSettings.razor
@@ -1,9 +1,9 @@
 @page "/settings/balloons"
 @using FlightPrep.Domain.Models
-@using FlightPrep.Infrastructure.Data
+@using FlightPrep.Domain.Services
 @attribute [Authorize]
 @rendermode InteractiveServer
-@inject IDbContextFactory<AppDbContext> DbFactory
+@inject IBalloonService BalloonSvc
 @inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>Ballonnen – FlightPrep</PageTitle>

--- a/src/FlightPrep/Components/Pages/Settings/BalloonSettings.razor.cs
+++ b/src/FlightPrep/Components/Pages/Settings/BalloonSettings.razor.cs
@@ -1,13 +1,13 @@
 using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
 namespace FlightPrep.Components.Pages.Settings;
 
-public partial class BalloonSettings: ComponentBase
+public partial class BalloonSettings : ComponentBase
 {
-        private List<Balloon> _balloons = [];
+    private List<Balloon> _balloons = [];
     private int? _editId;
     private Balloon _editBalloon = new();
     private bool _addingNew;
@@ -27,14 +27,7 @@ public partial class BalloonSettings: ComponentBase
 
     private async Task Load()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var query = db.Balloons.AsQueryable();
-        if (!_isAdmin)
-        {
-            if (_userId == null) { _balloons = []; return; }
-            query = query.Where(b => b.OwnerId == _userId);
-        }
-        _balloons = await query.OrderBy(b => b.Registration).ToListAsync();
+        _balloons = await BalloonSvc.GetAllAsync(_userId, _isAdmin);
     }
 
     private void StartEdit(Balloon b)
@@ -68,13 +61,7 @@ public partial class BalloonSettings: ComponentBase
         }
 
         _editError = null;
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var b = await db.Balloons.FindAsync(_editBalloon.Id);
-        if (b is null || (!_isAdmin && b.OwnerId != _userId)) return;
-        var originalOwnerId = b.OwnerId;
-        db.Entry(b).CurrentValues.SetValues(_editBalloon);
-        b.OwnerId = originalOwnerId;
-        await db.SaveChangesAsync();
+        await BalloonSvc.UpdateAsync(_editBalloon, _userId, _isAdmin);
         _editId = null;
         await Load();
     }
@@ -88,25 +75,14 @@ public partial class BalloonSettings: ComponentBase
         }
 
         _newError = null;
-        _newBalloon.OwnerId = _userId;
-        await using var db = await DbFactory.CreateDbContextAsync();
-        db.Balloons.Add(_newBalloon);
-        await db.SaveChangesAsync();
+        await BalloonSvc.AddAsync(_newBalloon, _userId);
         _addingNew = false;
         await Load();
     }
 
     private async Task DeleteBalloon(int id)
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var b = await db.Balloons.FindAsync(id);
-        if (b != null && (_isAdmin || b.OwnerId == _userId))
-        {
-            db.Balloons.Remove(b);
-            await db.SaveChangesAsync();
-        }
-
+        await BalloonSvc.DeleteAsync(id, _userId, _isAdmin);
         await Load();
     }
-
 }

--- a/src/FlightPrep/Components/Pages/Settings/LocationSettings.razor
+++ b/src/FlightPrep/Components/Pages/Settings/LocationSettings.razor
@@ -1,9 +1,9 @@
 @page "/settings/locations"
 @using FlightPrep.Domain.Models
-@using FlightPrep.Infrastructure.Data
+@using FlightPrep.Domain.Services
 @attribute [Authorize]
 @rendermode InteractiveServer
-@inject IDbContextFactory<AppDbContext> DbFactory
+@inject ILocationService LocationSvc
 @inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>Locaties – FlightPrep</PageTitle>

--- a/src/FlightPrep/Components/Pages/Settings/LocationSettings.razor.cs
+++ b/src/FlightPrep/Components/Pages/Settings/LocationSettings.razor.cs
@@ -1,13 +1,13 @@
 using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
 namespace FlightPrep.Components.Pages.Settings;
 
 public partial class LocationSettings : ComponentBase
 {
-       private List<Location> _locations = [];
+    private List<Location> _locations = [];
     private int? _editId;
     private Location _editLoc = new();
     private bool _addingNew;
@@ -25,14 +25,7 @@ public partial class LocationSettings : ComponentBase
 
     private async Task Load()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var query = db.Locations.AsQueryable();
-        if (!_isAdmin)
-        {
-            if (_userId == null) { _locations = []; return; }
-            query = query.Where(l => l.OwnerId == _userId);
-        }
-        _locations = await query.OrderBy(l => l.Name).ToListAsync();
+        _locations = await LocationSvc.GetAllAsync(_userId, _isAdmin);
     }
 
     private void StartEdit(Location l)
@@ -47,38 +40,21 @@ public partial class LocationSettings : ComponentBase
 
     private async Task SaveEdit()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var l = await db.Locations.FindAsync(_editLoc.Id);
-        if (l is null || (!_isAdmin && l.OwnerId != _userId)) return;
-        var originalOwnerId = l.OwnerId;
-        db.Entry(l).CurrentValues.SetValues(_editLoc);
-        l.OwnerId = originalOwnerId;
-        await db.SaveChangesAsync();
+        await LocationSvc.UpdateAsync(_editLoc, _userId, _isAdmin);
         _editId = null;
         await Load();
     }
 
     private async Task SaveNew()
     {
-        _newLoc.OwnerId = _userId;
-        await using var db = await DbFactory.CreateDbContextAsync();
-        db.Locations.Add(_newLoc);
-        await db.SaveChangesAsync();
+        await LocationSvc.AddAsync(_newLoc, _userId);
         _addingNew = false;
         await Load();
     }
 
     private async Task DeleteLocation(int id)
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var l = await db.Locations.FindAsync(id);
-        if (l != null && (_isAdmin || l.OwnerId == _userId))
-        {
-            db.Locations.Remove(l);
-            await db.SaveChangesAsync();
-        }
-
+        await LocationSvc.DeleteAsync(id, _userId, _isAdmin);
         await Load();
     }
-
 }

--- a/src/FlightPrep/Components/Pages/Settings/PilotSettings.razor
+++ b/src/FlightPrep/Components/Pages/Settings/PilotSettings.razor
@@ -1,9 +1,9 @@
 @page "/settings/pilots"
 @using FlightPrep.Domain.Models
-@using FlightPrep.Infrastructure.Data
+@using FlightPrep.Domain.Services
 @attribute [Authorize]
 @rendermode InteractiveServer
-@inject IDbContextFactory<AppDbContext> DbFactory
+@inject IPilotService PilotSvc
 @inject AuthenticationStateProvider AuthStateProvider
 
 <PageTitle>Piloten – FlightPrep</PageTitle>

--- a/src/FlightPrep/Components/Pages/Settings/PilotSettings.razor.cs
+++ b/src/FlightPrep/Components/Pages/Settings/PilotSettings.razor.cs
@@ -1,13 +1,13 @@
 using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 
 namespace FlightPrep.Components.Pages.Settings;
 
-public partial class PilotSettings: ComponentBase
+public partial class PilotSettings : ComponentBase
 {
-       private List<Pilot> _pilots = [];
+    private List<Pilot> _pilots = [];
     private int? _editId;
     private Pilot _editPilot = new();
     private bool _addingNew;
@@ -25,14 +25,7 @@ public partial class PilotSettings: ComponentBase
 
     private async Task Load()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var query = db.Pilots.AsQueryable();
-        if (!_isAdmin)
-        {
-            if (_userId == null) { _pilots = []; return; }
-            query = query.Where(p => p.OwnerId == _userId);
-        }
-        _pilots = await query.OrderBy(p => p.Name).ToListAsync();
+        _pilots = await PilotSvc.GetAllAsync(_userId, _isAdmin);
     }
 
     private void StartEdit(Pilot p)
@@ -47,37 +40,21 @@ public partial class PilotSettings: ComponentBase
 
     private async Task SaveEdit()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var p = await db.Pilots.FindAsync(_editPilot.Id);
-        if (p is null || (!_isAdmin && p.OwnerId != _userId)) return;
-        var originalOwnerId = p.OwnerId;
-        db.Entry(p).CurrentValues.SetValues(_editPilot);
-        p.OwnerId = originalOwnerId;
-        await db.SaveChangesAsync();
+        await PilotSvc.UpdateAsync(_editPilot, _userId, _isAdmin);
         _editId = null;
         await Load();
     }
 
     private async Task SaveNew()
     {
-        _newPilot.OwnerId = _userId;
-        await using var db = await DbFactory.CreateDbContextAsync();
-        db.Pilots.Add(_newPilot);
-        await db.SaveChangesAsync();
+        await PilotSvc.AddAsync(_newPilot, _userId);
         _addingNew = false;
         await Load();
     }
 
     private async Task DeletePilot(int id)
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var p = await db.Pilots.FindAsync(id);
-        if (p != null && (_isAdmin || p.OwnerId == _userId))
-        {
-            db.Pilots.Remove(p);
-            await db.SaveChangesAsync();
-        }
+        await PilotSvc.DeleteAsync(id, _userId, _isAdmin);
         await Load();
     }
-
 }

--- a/src/FlightPrep/Program.cs
+++ b/src/FlightPrep/Program.cs
@@ -74,7 +74,9 @@ builder.Services.AddScoped<IGoNoGoService, GoNoGoService>();
 builder.Services.AddScoped<IOFPSettingsService, OFPSettingsService>();
 builder.Services.AddScoped<IFlightAssessmentService, FlightAssessmentService>();
 builder.Services.AddScoped<IFlightPreparationService, FlightPreparationService>();
-// Data protection keys persist to /root/.aspnet/DataProtection-Keys (mounted as Docker volume)
+builder.Services.AddScoped<IPilotService, PilotService>();
+builder.Services.AddScoped<IBalloonService, BalloonService>();
+builder.Services.AddScoped<ILocationService, LocationService>();
 
 // Application Insights — only active when APPLICATIONINSIGHTS_CONNECTION_STRING is set
 if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
@@ -126,12 +128,9 @@ builder.Services.AddRazorPages();
 
 var app = builder.Build();
 
-// Auto-apply migrations and seed admin
+// Auto-seed admin on startup (migrations are applied via CI/CD pipeline)
 using (var scope = app.Services.CreateScope())
 {
-    var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-    using var db = dbFactory.CreateDbContext();
-    db.Database.Migrate();
     await AdminSeeder.SeedAdminAsync(scope.ServiceProvider);
 }
 

--- a/src/FlightPrep/Program.cs
+++ b/src/FlightPrep/Program.cs
@@ -128,9 +128,12 @@ builder.Services.AddRazorPages();
 
 var app = builder.Build();
 
-// Auto-seed admin on startup (migrations are applied via CI/CD pipeline)
+// Apply migrations (no-op in prod where CI/CD already migrated; required for docker-compose and local dev)
 using (var scope = app.Services.CreateScope())
 {
+    var dbCtx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    await dbCtx.Database.MigrateAsync();   // no-op in prod, required for docker-compose
+
     await AdminSeeder.SeedAdminAsync(scope.ServiceProvider);
 }
 

--- a/src/FlightPrep/Services/BalloonService.cs
+++ b/src/FlightPrep/Services/BalloonService.cs
@@ -55,6 +55,7 @@ public class BalloonService(
     public async Task AddAsync(Balloon newBalloon, string? userId)
     {
         ArgumentNullException.ThrowIfNull(newBalloon);
+        if (userId is null) return;   // [Authorize] prevents this in practice, but guard explicitly
 
         newBalloon.OwnerId = userId;
         await using var db = await dbFactory.CreateDbContextAsync();

--- a/src/FlightPrep/Services/BalloonService.cs
+++ b/src/FlightPrep/Services/BalloonService.cs
@@ -1,0 +1,79 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
+using FlightPrep.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FlightPrep.Services;
+
+/// <summary>
+///     Encapsulates all EF Core read/write operations for <see cref="Balloon" /> entities.
+///     Pages must not inject <see cref="IDbContextFactory{AppDbContext}" /> directly;
+///     all persistence flows through this service.
+/// </summary>
+public class BalloonService(
+    IDbContextFactory<AppDbContext> dbFactory,
+    ILogger<BalloonService> logger) : IBalloonService
+{
+    /// <inheritdoc />
+    public async Task<List<Balloon>> GetAllAsync(string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var query = db.Balloons.AsQueryable();
+        if (!isAdmin)
+        {
+            if (userId == null)
+            {
+                return [];
+            }
+
+            query = query.Where(b => b.OwnerId == userId);
+        }
+
+        return await query.OrderBy(b => b.Registration).ToListAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAsync(Balloon editBalloon, string? userId, bool isAdmin)
+    {
+        ArgumentNullException.ThrowIfNull(editBalloon);
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var b = await db.Balloons.FindAsync(editBalloon.Id);
+        if (b is null || (!isAdmin && b.OwnerId != userId))
+        {
+            logger.LogDebug("UpdateAsync: balloon {Id} not found or access denied for user {UserId}.", editBalloon.Id, userId);
+            return;
+        }
+
+        var originalOwnerId = b.OwnerId;
+        db.Entry(b).CurrentValues.SetValues(editBalloon);
+        b.OwnerId = originalOwnerId;
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(Balloon newBalloon, string? userId)
+    {
+        ArgumentNullException.ThrowIfNull(newBalloon);
+
+        newBalloon.OwnerId = userId;
+        await using var db = await dbFactory.CreateDbContextAsync();
+        db.Balloons.Add(newBalloon);
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(int id, string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var b = await db.Balloons.FindAsync(id);
+        if (b is null || (!isAdmin && b.OwnerId != userId))
+        {
+            logger.LogDebug("DeleteAsync: balloon {Id} not found or access denied for user {UserId}.", id, userId);
+            return;
+        }
+
+        db.Balloons.Remove(b);
+        await db.SaveChangesAsync();
+    }
+}

--- a/src/FlightPrep/Services/LocationService.cs
+++ b/src/FlightPrep/Services/LocationService.cs
@@ -1,0 +1,79 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
+using FlightPrep.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FlightPrep.Services;
+
+/// <summary>
+///     Encapsulates all EF Core read/write operations for <see cref="Location" /> entities.
+///     Pages must not inject <see cref="IDbContextFactory{AppDbContext}" /> directly;
+///     all persistence flows through this service.
+/// </summary>
+public class LocationService(
+    IDbContextFactory<AppDbContext> dbFactory,
+    ILogger<LocationService> logger) : ILocationService
+{
+    /// <inheritdoc />
+    public async Task<List<Location>> GetAllAsync(string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var query = db.Locations.AsQueryable();
+        if (!isAdmin)
+        {
+            if (userId == null)
+            {
+                return [];
+            }
+
+            query = query.Where(l => l.OwnerId == userId);
+        }
+
+        return await query.OrderBy(l => l.Name).ToListAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAsync(Location editLoc, string? userId, bool isAdmin)
+    {
+        ArgumentNullException.ThrowIfNull(editLoc);
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var l = await db.Locations.FindAsync(editLoc.Id);
+        if (l is null || (!isAdmin && l.OwnerId != userId))
+        {
+            logger.LogDebug("UpdateAsync: location {Id} not found or access denied for user {UserId}.", editLoc.Id, userId);
+            return;
+        }
+
+        var originalOwnerId = l.OwnerId;
+        db.Entry(l).CurrentValues.SetValues(editLoc);
+        l.OwnerId = originalOwnerId;
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(Location newLoc, string? userId)
+    {
+        ArgumentNullException.ThrowIfNull(newLoc);
+
+        newLoc.OwnerId = userId;
+        await using var db = await dbFactory.CreateDbContextAsync();
+        db.Locations.Add(newLoc);
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(int id, string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var l = await db.Locations.FindAsync(id);
+        if (l is null || (!isAdmin && l.OwnerId != userId))
+        {
+            logger.LogDebug("DeleteAsync: location {Id} not found or access denied for user {UserId}.", id, userId);
+            return;
+        }
+
+        db.Locations.Remove(l);
+        await db.SaveChangesAsync();
+    }
+}

--- a/src/FlightPrep/Services/LocationService.cs
+++ b/src/FlightPrep/Services/LocationService.cs
@@ -55,6 +55,7 @@ public class LocationService(
     public async Task AddAsync(Location newLoc, string? userId)
     {
         ArgumentNullException.ThrowIfNull(newLoc);
+        if (userId is null) return;   // [Authorize] prevents this in practice, but guard explicitly
 
         newLoc.OwnerId = userId;
         await using var db = await dbFactory.CreateDbContextAsync();

--- a/src/FlightPrep/Services/PilotService.cs
+++ b/src/FlightPrep/Services/PilotService.cs
@@ -55,6 +55,7 @@ public class PilotService(
     public async Task AddAsync(Pilot newPilot, string? userId)
     {
         ArgumentNullException.ThrowIfNull(newPilot);
+        if (userId is null) return;   // [Authorize] prevents this in practice, but guard explicitly
 
         newPilot.OwnerId = userId;
         await using var db = await dbFactory.CreateDbContextAsync();

--- a/src/FlightPrep/Services/PilotService.cs
+++ b/src/FlightPrep/Services/PilotService.cs
@@ -1,0 +1,79 @@
+using FlightPrep.Domain.Models;
+using FlightPrep.Domain.Services;
+using FlightPrep.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FlightPrep.Services;
+
+/// <summary>
+///     Encapsulates all EF Core read/write operations for <see cref="Pilot" /> entities.
+///     Pages must not inject <see cref="IDbContextFactory{AppDbContext}" /> directly;
+///     all persistence flows through this service.
+/// </summary>
+public class PilotService(
+    IDbContextFactory<AppDbContext> dbFactory,
+    ILogger<PilotService> logger) : IPilotService
+{
+    /// <inheritdoc />
+    public async Task<List<Pilot>> GetAllAsync(string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var query = db.Pilots.AsQueryable();
+        if (!isAdmin)
+        {
+            if (userId == null)
+            {
+                return [];
+            }
+
+            query = query.Where(p => p.OwnerId == userId);
+        }
+
+        return await query.OrderBy(p => p.Name).ToListAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAsync(Pilot editPilot, string? userId, bool isAdmin)
+    {
+        ArgumentNullException.ThrowIfNull(editPilot);
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var p = await db.Pilots.FindAsync(editPilot.Id);
+        if (p is null || (!isAdmin && p.OwnerId != userId))
+        {
+            logger.LogDebug("UpdateAsync: pilot {Id} not found or access denied for user {UserId}.", editPilot.Id, userId);
+            return;
+        }
+
+        var originalOwnerId = p.OwnerId;
+        db.Entry(p).CurrentValues.SetValues(editPilot);
+        p.OwnerId = originalOwnerId;
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(Pilot newPilot, string? userId)
+    {
+        ArgumentNullException.ThrowIfNull(newPilot);
+
+        newPilot.OwnerId = userId;
+        await using var db = await dbFactory.CreateDbContextAsync();
+        db.Pilots.Add(newPilot);
+        await db.SaveChangesAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(int id, string? userId, bool isAdmin)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var p = await db.Pilots.FindAsync(id);
+        if (p is null || (!isAdmin && p.OwnerId != userId))
+        {
+            logger.LogDebug("DeleteAsync: pilot {Id} not found or access denied for user {UserId}.", id, userId);
+            return;
+        }
+
+        db.Pilots.Remove(p);
+        await db.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #26, #30

---

## #30 — Auto-migration moved to CI/CD pipeline

- **`.github/workflows/ci-cd.yml`** — Added checkout, .NET setup, and `dotnet ef database update` step in the deploy job **before** the Azure deploy step. Uses `secrets.AZURE_POSTGRESQL_CONNECTION_STRING`.
- **`Program.cs`** — `MigrateAsync()` kept for docker-compose/local dev (no-op in production after CI/CD migrates). `AdminSeeder` still runs after migration.
- dotnet-ef tool install uses `|| dotnet tool update` fallback to enforce pinned version 9.0.5.

## #26 — Settings pages extract to service layer

**New interfaces** (FlightPrep.Domain/Services):
- `IPilotService` — GetAllAsync, AddAsync, UpdateAsync, DeleteAsync
- `IBalloonService` — GetAllAsync, AddAsync, UpdateAsync, DeleteAsync
- `ILocationService` — GetAllAsync, AddAsync, UpdateAsync, DeleteAsync

**New implementations** (FlightPrep/Services):
- `PilotService`, `BalloonService`, `LocationService` — all use `IDbContextFactory<AppDbContext>`, ownership enforced, OwnerId preserved on update, null userId guard on AddAsync

**Settings pages updated:**
- `PilotSettings.razor` + `.razor.cs` — injects `IPilotService`
- `BalloonSettings.razor` + `.razor.cs` — injects `IBalloonService`
- `LocationSettings.razor` + `.razor.cs` — injects `ILocationService`
- `GoNoGoSettingsPage` — was already using `IGoNoGoService`, no changes needed

## Tests

428/428 passing ✅ (30 new tests across PilotServiceTests, BalloonServiceTests, LocationServiceTests)