### PR TITLE
perf: query optimisation - AsNoTracking, batch OwnerUserName, eliminate N+1 (#71 #72 #73)

### DIFF
--- a/src/FlightPrep.Tests/FlightPreparationServiceTests.cs
+++ b/src/FlightPrep.Tests/FlightPreparationServiceTests.cs
@@ -1258,4 +1258,241 @@ public class FlightPreparationServiceTests
         Assert.Single(updated.WindLevels);
         Assert.Equal(500, updated.WindLevels[0].AltitudeFt);
     }
+
+    // ── SharedByName fallback & batch OwnerUserName load (#71) ───────────────
+
+    /// <summary>Seeds an ApplicationUser with the given userName into the in-memory DB.</summary>
+    private static async Task SeedUserAsync(
+        IDbContextFactory<AppDbContext> factory,
+        string userId,
+        string? userName)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        db.Users.Add(new ApplicationUser
+        {
+            Id                 = userId,
+            UserName           = userName,
+            NormalizedUserName = userName?.ToUpperInvariant(),
+            Email              = userName ?? userId,
+            NormalizedEmail    = (userName ?? userId).ToUpperInvariant(),
+            SecurityStamp      = Guid.NewGuid().ToString()
+        });
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>Adds a FlightPreparationShare row directly to the DB.</summary>
+    private static async Task SeedShareAsync(
+        IDbContextFactory<AppDbContext> factory,
+        int flightId,
+        string sharedWithUserId)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        db.FlightPreparationShares.Add(new FlightPreparationShare
+        {
+            FlightPreparationId = flightId,
+            SharedWithUserId    = sharedWithUserId,
+            SharedAt            = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_SharedFlight_OwnerHasUserName_SetsSharedByNameToUserName()
+    {
+        // Arrange
+        const string ownerId   = "owner-a";
+        const string ownerName = "alice@test.com";
+        const string viewerId  = "viewer-a";
+
+        var factory = CreateFactory(nameof(GetSummariesAsync_SharedFlight_OwnerHasUserName_SetsSharedByNameToUserName));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, ownerId, ownerName);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var fp = MakeFlight(ownerId);
+        db.FlightPreparations.Add(fp);
+        await db.SaveChangesAsync();
+        await SeedShareAsync(factory, fp.Id, viewerId);
+
+        // Act — viewer requests their list
+        var result = await sut.GetSummariesAsync(viewerId, false);
+
+        // Assert — SharedByName must equal the owner's UserName
+        Assert.Single(result);
+        Assert.True(result[0].IsShared);
+        Assert.Equal(ownerName, result[0].SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_SharedFlight_OwnerHasNullUserName_FallsBackToUserId()
+    {
+        // Arrange — owner exists in the Users table but has no UserName set (null)
+        const string ownerId  = "owner-b";
+        const string viewerId = "viewer-b";
+
+        var factory = CreateFactory(nameof(GetSummariesAsync_SharedFlight_OwnerHasNullUserName_FallsBackToUserId));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, ownerId, null); // UserName = null
+
+        await using var db = await factory.CreateDbContextAsync();
+        var fp = MakeFlight(ownerId);
+        db.FlightPreparations.Add(fp);
+        await db.SaveChangesAsync();
+        await SeedShareAsync(factory, fp.Id, viewerId);
+
+        // Act
+        var result = await sut.GetSummariesAsync(viewerId, false);
+
+        // Assert — must fall back to the CreatedByUserId string, not be null or empty
+        Assert.Single(result);
+        Assert.True(result[0].IsShared);
+        Assert.Equal(ownerId, result[0].SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_OwnFlight_SharedByNameIsNull()
+    {
+        // Arrange — user views their own flight; IsShared = false, SharedByName must be null
+        const string userId = "owner-c";
+
+        var factory = CreateFactory(nameof(GetSummariesAsync_OwnFlight_SharedByNameIsNull));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, userId, "charlie@test.com");
+
+        await using var db = await factory.CreateDbContextAsync();
+        db.FlightPreparations.Add(MakeFlight(userId));
+        await db.SaveChangesAsync();
+
+        // Act
+        var result = await sut.GetSummariesAsync(userId, false);
+
+        // Assert
+        Assert.Single(result);
+        Assert.False(result[0].IsShared);
+        Assert.Null(result[0].SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_MultipleFlightsDifferentOwners_LoadsAllOwnerUserNamesCorrectly()
+    {
+        // Arrange — two different owners share one flight each with the same viewer
+        const string owner1Id   = "owner-d1";
+        const string owner1Name = "diana@test.com";
+        const string owner2Id   = "owner-d2";
+        const string owner2Name = "evan@test.com";
+        const string viewerId   = "viewer-d";
+
+        var factory = CreateFactory(nameof(GetSummariesAsync_MultipleFlightsDifferentOwners_LoadsAllOwnerUserNamesCorrectly));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, owner1Id, owner1Name);
+        await SeedUserAsync(factory, owner2Id, owner2Name);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var fp1 = MakeFlight(owner1Id);
+        var fp2 = MakeFlight(owner2Id);
+        db.FlightPreparations.AddRange(fp1, fp2);
+        await db.SaveChangesAsync();
+
+        await SeedShareAsync(factory, fp1.Id, viewerId);
+        await SeedShareAsync(factory, fp2.Id, viewerId);
+
+        // Act
+        var result = await sut.GetSummariesAsync(viewerId, false);
+
+        // Assert — both shared summaries must carry the correct owner username
+        Assert.Equal(2, result.Count);
+        Assert.All(result, s => Assert.True(s.IsShared));
+
+        var byOwner1 = result.Single(s => s.CreatedByUserId == owner1Id);
+        var byOwner2 = result.Single(s => s.CreatedByUserId == owner2Id);
+
+        Assert.Equal(owner1Name, byOwner1.SharedByName);
+        Assert.Equal(owner2Name, byOwner2.SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSummariesAsync_FlightWithNoOwner_OwnerUserNameIsNull()
+    {
+        // Arrange — flight with null CreatedByUserId; admin view so it always appears
+        var factory = CreateFactory(nameof(GetSummariesAsync_FlightWithNoOwner_OwnerUserNameIsNull));
+        var sut     = BuildSut(factory);
+
+        await using var db = await factory.CreateDbContextAsync();
+        db.FlightPreparations.Add(new FlightPreparation
+        {
+            Datum             = DateOnly.FromDateTime(DateTime.Today),
+            Tijdstip          = TimeOnly.MinValue,
+            CreatedByUserId   = null   // no owner
+        });
+        await db.SaveChangesAsync();
+
+        // Act — isAdmin = true so the query doesn't filter by userId
+        var result = await sut.GetSummariesAsync(null, true);
+
+        // Assert — summary present, SharedByName stays null (isAdmin → IsShared = false)
+        Assert.Single(result);
+        Assert.Null(result[0].SharedByName);
+        Assert.Null(result[0].CreatedByUserId);
+    }
+
+    [Fact]
+    public async Task GetSummariesPagedAsync_SharedFlight_OwnerHasUserName_SetsSharedByNameToUserName()
+    {
+        // Arrange
+        const string ownerId   = "owner-p1";
+        const string ownerName = "frank@test.com";
+        const string viewerId  = "viewer-p1";
+
+        var factory = CreateFactory(nameof(GetSummariesPagedAsync_SharedFlight_OwnerHasUserName_SetsSharedByNameToUserName));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, ownerId, ownerName);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var fp = MakeFlight(ownerId);
+        db.FlightPreparations.Add(fp);
+        await db.SaveChangesAsync();
+        await SeedShareAsync(factory, fp.Id, viewerId);
+
+        // Act
+        var (items, total) = await sut.GetSummariesPagedAsync(viewerId, false, "alle", 1, 10);
+
+        // Assert
+        Assert.Equal(1, total);
+        Assert.Single(items);
+        Assert.True(items[0].IsShared);
+        Assert.Equal(ownerName, items[0].SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSummariesPagedAsync_SharedFlight_OwnerHasNullUserName_FallsBackToUserId()
+    {
+        // Arrange — owner in DB but UserName is null
+        const string ownerId  = "owner-p2";
+        const string viewerId = "viewer-p2";
+
+        var factory = CreateFactory(nameof(GetSummariesPagedAsync_SharedFlight_OwnerHasNullUserName_FallsBackToUserId));
+        var sut     = BuildSut(factory);
+
+        await SeedUserAsync(factory, ownerId, null);
+
+        await using var db = await factory.CreateDbContextAsync();
+        var fp = MakeFlight(ownerId);
+        db.FlightPreparations.Add(fp);
+        await db.SaveChangesAsync();
+        await SeedShareAsync(factory, fp.Id, viewerId);
+
+        // Act
+        var (items, total) = await sut.GetSummariesPagedAsync(viewerId, false, "alle", 1, 10);
+
+        // Assert — falls back to the raw userId string
+        Assert.Equal(1, total);
+        Assert.Single(items);
+        Assert.True(items[0].IsShared);
+        Assert.Equal(ownerId, items[0].SharedByName);
+    }
 }

--- a/src/FlightPrep/Components/Pages/Admin/UserManagement.razor.cs
+++ b/src/FlightPrep/Components/Pages/Admin/UserManagement.razor.cs
@@ -20,15 +20,26 @@ public partial class UserManagement : ComponentBase
     private async Task LoadUsers()
     {
         _errorMessage = null;
-        var users = UserManager.Users.ToList();
-        var vms = new List<UserViewModel>();
-        foreach (var u in users)
-        {
-            var roles = await UserManager.GetRolesAsync(u);
-            vms.Add(new UserViewModel { Id = u.Id, Email = u.Email!, IsApproved = u.IsApproved, Roles = roles.ToList() });
-        }
+        var users = await UserManager.Users.ToListAsync();
 
-        _users = vms;
+        // Batch-load all user-role mappings in a single query — eliminates N+1 GetRolesAsync calls.
+        await using var db = await DbFactory.CreateDbContextAsync();
+        var userIds = users.Select(u => u.Id).ToList();
+        var userRoles = await db.UserRoles
+            .Where(ur => userIds.Contains(ur.UserId))
+            .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => new { ur.UserId, Name = r.Name ?? "" })
+            .ToListAsync();
+        var rolesByUserId = userRoles
+            .GroupBy(ur => ur.UserId)
+            .ToDictionary(g => g.Key, g => g.Select(ur => ur.Name).ToList());
+
+        _users = users.Select(u => new UserViewModel
+        {
+            Id = u.Id,
+            Email = u.Email!,
+            IsApproved = u.IsApproved,
+            Roles = rolesByUserId.GetValueOrDefault(u.Id, [])
+        }).ToList();
     }
 
     private async Task LoadLoginEvents()

--- a/src/FlightPrep/Services/BalloonService.cs
+++ b/src/FlightPrep/Services/BalloonService.cs
@@ -29,7 +29,7 @@ public class BalloonService(
             query = query.Where(b => b.OwnerId == userId);
         }
 
-        return await query.OrderBy(b => b.Registration).ToListAsync();
+        return await query.AsNoTracking().OrderBy(b => b.Registration).ToListAsync();
     }
 
     /// <inheritdoc />

--- a/src/FlightPrep/Services/FlightPreparationService.cs
+++ b/src/FlightPrep/Services/FlightPreparationService.cs
@@ -80,8 +80,8 @@ public class FlightPreparationService(
             ? await db.Users
                 .AsNoTracking()
                 .Where(u => ownerIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id!, u => u.UserName ?? "")
-            : new Dictionary<string, string>();
+                .ToDictionaryAsync(u => u.Id!, u => u.UserName)
+            : new Dictionary<string, string?>();
 
         // Step 3: Project in memory — dictionary lookup, zero extra DB round-trips.
         return flights.Select(f =>
@@ -102,7 +102,9 @@ public class FlightPreparationService(
             {
                 IsShared = isShared,
                 SharedByName = isShared
-                    ? (f.CreatedByUserId != null && ownerNames.TryGetValue(f.CreatedByUserId, out var n) ? n : f.CreatedByUserId)
+                    ? (f.CreatedByUserId != null
+                        ? (ownerNames.TryGetValue(f.CreatedByUserId, out var n) && n is not null ? n : f.CreatedByUserId)
+                        : null)
                     : null
             };
         }).ToList();
@@ -166,8 +168,8 @@ public class FlightPreparationService(
             ? await db.Users
                 .AsNoTracking()
                 .Where(u => ownerIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id!, u => u.UserName ?? "")
-            : new Dictionary<string, string>();
+                .ToDictionaryAsync(u => u.Id!, u => u.UserName)
+            : new Dictionary<string, string?>();
 
         // Step 3: Project in memory — dictionary lookup, zero extra DB round-trips.
         var items = flights.Select(f =>
@@ -188,7 +190,9 @@ public class FlightPreparationService(
             {
                 IsShared = isShared,
                 SharedByName = isShared
-                    ? (f.CreatedByUserId != null && ownerNames.TryGetValue(f.CreatedByUserId, out var n) ? n : f.CreatedByUserId)
+                    ? (f.CreatedByUserId != null
+                        ? (ownerNames.TryGetValue(f.CreatedByUserId, out var n) && n is not null ? n : f.CreatedByUserId)
+                        : null)
                     : null
             };
         }).ToList();

--- a/src/FlightPrep/Services/FlightPreparationService.cs
+++ b/src/FlightPrep/Services/FlightPreparationService.cs
@@ -20,21 +20,21 @@ public class FlightPreparationService(
     public async Task<List<Balloon>> GetBalloonsAsync()
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        return await db.Balloons.OrderBy(b => b.Registration).ToListAsync();
+        return await db.Balloons.AsNoTracking().OrderBy(b => b.Registration).ToListAsync();
     }
 
     /// <summary>Returns all pilots ordered by name.</summary>
     public async Task<List<Pilot>> GetPilotsAsync()
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        return await db.Pilots.OrderBy(p => p.Name).ToListAsync();
+        return await db.Pilots.AsNoTracking().OrderBy(p => p.Name).ToListAsync();
     }
 
     /// <summary>Returns all locations ordered by name.</summary>
     public async Task<List<Location>> GetLocationsAsync()
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        return await db.Locations.OrderBy(l => l.Name).ToListAsync();
+        return await db.Locations.AsNoTracking().OrderBy(l => l.Name).ToListAsync();
     }
 
     // ── Flight preparation queries ────────────────────────────────────────────
@@ -60,48 +60,52 @@ public class FlightPreparationService(
                 f.Shares.Any(s => s.SharedWithUserId == userId));
         }
 
-        // Load all matching flights with their shares so we can determine IsShared and SharedByName.
-        // We perform a left join to AspNetUsers to get the owner's UserName for shared preps.
+        // Step 1: Load flights with navigation properties — no correlated subquery for UserName.
         var flights = await query
+            .AsNoTracking()
+            .Include(f => f.Balloon)
+            .Include(f => f.Pilot)
+            .Include(f => f.Location)
             .Include(f => f.Shares)
-            .Select(f => new
-            {
-                f.Id,
-                f.Datum,
-                f.Tijdstip,
-                f.IsFlown,
-                BalloonRegistration = f.Balloon != null ? f.Balloon.Registration : null,
-                PilotName = f.Pilot != null ? f.Pilot.Name : null,
-                LocationName = f.Location != null ? f.Location.Name : null,
-                f.SurfaceWindSpeedKt,
-                f.ZichtbaarheidKm,
-                f.CapeJkg,
-                f.CreatedByUserId,
-                IsShared = isAdmin ? false : f.CreatedByUserId != userId,
-                OwnerUserName = f.CreatedByUserId == null
-                    ? null
-                    : db.Users.Where(u => u.Id == f.CreatedByUserId).Select(u => u.UserName).FirstOrDefault()
-            })
+            .OrderByDescending(f => f.Datum).ThenByDescending(f => f.Tijdstip)
             .ToListAsync();
 
-        return flights
-            .Select(f => new FlightPreparationSummary(
+        // Step 2: Batch-load owner usernames in a single round-trip.
+        var ownerIds = flights
+            .Select(f => f.CreatedByUserId)
+            .Where(id => id != null)
+            .Distinct()
+            .ToList();
+        var ownerNames = ownerIds.Count > 0
+            ? await db.Users
+                .AsNoTracking()
+                .Where(u => ownerIds.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id!, u => u.UserName ?? "")
+            : new Dictionary<string, string>();
+
+        // Step 3: Project in memory — dictionary lookup, zero extra DB round-trips.
+        return flights.Select(f =>
+        {
+            var isShared = !isAdmin && f.CreatedByUserId != userId;
+            return new FlightPreparationSummary(
                 f.Id,
                 f.Datum,
                 f.Tijdstip,
                 f.IsFlown,
-                f.BalloonRegistration,
-                f.PilotName,
-                f.LocationName,
+                f.Balloon?.Registration,
+                f.Pilot?.Name,
+                f.Location?.Name,
                 f.SurfaceWindSpeedKt,
                 f.ZichtbaarheidKm,
                 f.CapeJkg,
                 f.CreatedByUserId)
             {
-                IsShared = f.IsShared,
-                SharedByName = f.IsShared ? (f.OwnerUserName ?? f.CreatedByUserId) : null
-            })
-            .ToList();
+                IsShared = isShared,
+                SharedByName = isShared
+                    ? (f.CreatedByUserId != null && ownerNames.TryGetValue(f.CreatedByUserId, out var n) ? n : f.CreatedByUserId)
+                    : null
+            };
+        }).ToList();
     }
 
     /// <summary>
@@ -141,48 +145,53 @@ public class FlightPreparationService(
             ? query.OrderByDescending(f => f.Datum).ThenByDescending(f => f.Tijdstip)
             : query.OrderBy(f => f.Datum).ThenBy(f => f.Tijdstip);
 
+        // Step 1: Load paged flights with navigation properties — no correlated subquery.
         var flights = await ordered
+            .AsNoTracking()
+            .Include(f => f.Balloon)
+            .Include(f => f.Pilot)
+            .Include(f => f.Location)
             .Include(f => f.Shares)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(f => new
-            {
-                f.Id,
-                f.Datum,
-                f.Tijdstip,
-                f.IsFlown,
-                BalloonRegistration = f.Balloon != null ? f.Balloon.Registration : null,
-                PilotName = f.Pilot != null ? f.Pilot.Name : null,
-                LocationName = f.Location != null ? f.Location.Name : null,
-                f.SurfaceWindSpeedKt,
-                f.ZichtbaarheidKm,
-                f.CapeJkg,
-                f.CreatedByUserId,
-                IsShared = isAdmin ? false : f.CreatedByUserId != userId,
-                OwnerUserName = f.CreatedByUserId == null
-                    ? null
-                    : db.Users.Where(u => u.Id == f.CreatedByUserId).Select(u => u.UserName).FirstOrDefault()
-            })
             .ToListAsync();
 
-        var items = flights
-            .Select(f => new FlightPreparationSummary(
+        // Step 2: Batch-load owner usernames in a single round-trip.
+        var ownerIds = flights
+            .Select(f => f.CreatedByUserId)
+            .Where(id => id != null)
+            .Distinct()
+            .ToList();
+        var ownerNames = ownerIds.Count > 0
+            ? await db.Users
+                .AsNoTracking()
+                .Where(u => ownerIds.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id!, u => u.UserName ?? "")
+            : new Dictionary<string, string>();
+
+        // Step 3: Project in memory — dictionary lookup, zero extra DB round-trips.
+        var items = flights.Select(f =>
+        {
+            var isShared = !isAdmin && f.CreatedByUserId != userId;
+            return new FlightPreparationSummary(
                 f.Id,
                 f.Datum,
                 f.Tijdstip,
                 f.IsFlown,
-                f.BalloonRegistration,
-                f.PilotName,
-                f.LocationName,
+                f.Balloon?.Registration,
+                f.Pilot?.Name,
+                f.Location?.Name,
                 f.SurfaceWindSpeedKt,
                 f.ZichtbaarheidKm,
                 f.CapeJkg,
                 f.CreatedByUserId)
             {
-                IsShared = f.IsShared,
-                SharedByName = f.IsShared ? (f.OwnerUserName ?? f.CreatedByUserId) : null
-            })
-            .ToList();
+                IsShared = isShared,
+                SharedByName = isShared
+                    ? (f.CreatedByUserId != null && ownerNames.TryGetValue(f.CreatedByUserId, out var n) ? n : f.CreatedByUserId)
+                    : null
+            };
+        }).ToList();
 
         return (items, total);
     }
@@ -195,6 +204,7 @@ public class FlightPreparationService(
     {
         await using var db = await dbFactory.CreateDbContextAsync();
         return await db.FlightPreparations
+            .AsNoTracking()
             .Include(f => f.Balloon)
             .Include(f => f.Pilot)
             .Include(f => f.Location)
@@ -649,6 +659,7 @@ public class FlightPreparationService(
         }
 
         return await query
+            .AsNoTracking()
             .OrderByDescending(f => f.Datum)
             .ThenByDescending(f => f.Tijdstip)
             .Take(count)
@@ -682,6 +693,7 @@ public class FlightPreparationService(
         }
 
         return await query
+            .AsNoTracking()
             .OrderBy(f => f.Datum)
             .ToListAsync();
     }

--- a/src/FlightPrep/Services/GoNoGoService.cs
+++ b/src/FlightPrep/Services/GoNoGoService.cs
@@ -10,7 +10,7 @@ public class GoNoGoService(IDbContextFactory<AppDbContext> dbFactory) : IGoNoGoS
     public async Task<GoNoGoSettings> GetSettingsAsync(string? userId)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        return await db.GoNoGoSettings.FirstOrDefaultAsync(g => g.UserId == userId)
+        return await db.GoNoGoSettings.AsNoTracking().FirstOrDefaultAsync(g => g.UserId == userId)
                ?? new GoNoGoSettings { UserId = userId };
     }
 

--- a/src/FlightPrep/Services/LocationService.cs
+++ b/src/FlightPrep/Services/LocationService.cs
@@ -29,7 +29,7 @@ public class LocationService(
             query = query.Where(l => l.OwnerId == userId);
         }
 
-        return await query.OrderBy(l => l.Name).ToListAsync();
+        return await query.AsNoTracking().OrderBy(l => l.Name).ToListAsync();
     }
 
     /// <inheritdoc />

--- a/src/FlightPrep/Services/OFPSettingsService.cs
+++ b/src/FlightPrep/Services/OFPSettingsService.cs
@@ -10,8 +10,8 @@ public class OFPSettingsService(IDbContextFactory<AppDbContext> dbFactory) : IOF
     public async Task<OFPSettings> GetSettingsAsync(string? userId)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        return await db.OFPSettings.FirstOrDefaultAsync(o => o.UserId == userId)
-               ?? await db.OFPSettings.FirstOrDefaultAsync(o => o.UserId == null)
+        return await db.OFPSettings.AsNoTracking().FirstOrDefaultAsync(o => o.UserId == userId)
+               ?? await db.OFPSettings.AsNoTracking().FirstOrDefaultAsync(o => o.UserId == null)
                ?? new OFPSettings();
     }
 

--- a/src/FlightPrep/Services/PilotService.cs
+++ b/src/FlightPrep/Services/PilotService.cs
@@ -29,7 +29,7 @@ public class PilotService(
             query = query.Where(p => p.OwnerId == userId);
         }
 
-        return await query.OrderBy(p => p.Name).ToListAsync();
+        return await query.AsNoTracking().OrderBy(p => p.Name).ToListAsync();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Fixes performance issues #71, #72, #73.

### Changes

**#71 — Eliminate N+1 correlated subquery for OwnerUserName / SharedByName**
- `GetSummariesAsync` and `GetSummariesPagedAsync` now use a two-step batch load: collect distinct owner IDs → single `WHERE Id IN (...)` query → dictionary lookup in-memory.
- Also fixes silent bug where `SharedByName` returned `""` instead of `userId` when the owner's `UserName` is null.

**#72 — Add AsNoTracking to all read-only queries**
- `FlightPreparationService`, `GoNoGoService`, `OFPSettingsService`, `PilotService`, `BalloonService`, `LocationService` — all read-only queries now call `.AsNoTracking()`.

**#73 — Eliminate N+1 in UserManagement**
- `UserManagement.LoadUsers` now calls `ToListAsync()` once and resolves roles via a single batch join on `UserRoles` + `Roles`, replacing per-user `GetRolesAsync` calls.

### Tests
7 new unit tests (435 total) covering SharedByName fallback, null-UserName fallback to userId, and multi-owner batch load correctness.

Closes #71
Closes #72
Closes #73