### PR TITLE
refactor: rename Dutch model properties to English equivalents (#34)

### DIFF
--- a/src/FlightPrep.Domain.Tests/FlightAssessmentServiceTests.cs
+++ b/src/FlightPrep.Domain.Tests/FlightAssessmentServiceTests.cs
@@ -207,7 +207,7 @@ public class FlightAssessmentServiceTests
     {
         // Arrange
         var sut = BuildSutWithRealGoNoGo();
-        var fp = new FlightPreparation { SurfaceWindSpeedKt = null, ZichtbaarheidKm = null, CapeJkg = null, TotaalLiftKg = 1000 };
+        var fp = new FlightPreparation { SurfaceWindSpeedKt = null, VisibilityKm = null, CapeJkg = null, TotaalLiftKg = 1000 };
 
         // Act
         var result = sut.Compute(fp, DefaultSettings());

--- a/src/FlightPrep.Domain.Tests/FlightPreparationSummaryTests.cs
+++ b/src/FlightPrep.Domain.Tests/FlightPreparationSummaryTests.cs
@@ -31,14 +31,14 @@ public class FlightPreparationSummaryTests
 
         // Assert
         Assert.Equal(42, summary.Id);
-        Assert.Equal(datum, summary.Datum);
-        Assert.Equal(tijdstip, summary.Tijdstip);
+        Assert.Equal(datum, summary.Date);
+        Assert.Equal(tijdstip, summary.Time);
         Assert.True(summary.IsFlown);
         Assert.Equal("OO-BUT", summary.BalloonRegistration);
         Assert.Equal("Jan Peeters", summary.PilotName);
         Assert.Equal("Leuven", summary.LocationName);
         Assert.Equal(8.5, summary.SurfaceWindSpeedKt);
-        Assert.Equal(10, summary.ZichtbaarheidKm);
+        Assert.Equal(10, summary.VisibilityKm);
         Assert.Equal(250, summary.CapeJkg);
     }
 
@@ -64,7 +64,7 @@ public class FlightPreparationSummaryTests
         Assert.Null(summary.PilotName);
         Assert.Null(summary.LocationName);
         Assert.Null(summary.SurfaceWindSpeedKt);
-        Assert.Null(summary.ZichtbaarheidKm);
+        Assert.Null(summary.VisibilityKm);
         Assert.Null(summary.CapeJkg);
         Assert.False(summary.IsFlown);
     }

--- a/src/FlightPrep.Domain/Models/FlightPreparation.cs
+++ b/src/FlightPrep.Domain/Models/FlightPreparation.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace FlightPrep.Domain.Models;
 
 public class FlightPreparation
@@ -8,46 +10,65 @@ public class FlightPreparation
     public string? CreatedByUserId { get; set; }
 
     // Section 1 - Algemene Gegevens
-    public DateOnly Datum { get; set; } = DateOnly.FromDateTime(DateTime.Today);
-    public TimeOnly Tijdstip { get; set; } = TimeOnly.FromDateTime(DateTime.Now);
+    [Column("Datum")]
+    public DateOnly Date { get; set; } = DateOnly.FromDateTime(DateTime.Today);
+    [Column("Tijdstip")]
+    public TimeOnly Time { get; set; } = TimeOnly.FromDateTime(DateTime.Now);
     public int? BalloonId { get; set; }
     public Balloon? Balloon { get; set; }
     public int? PilotId { get; set; }
     public Pilot? Pilot { get; set; }
     public int? LocationId { get; set; }
     public Location? Location { get; set; }
-    public bool VeldEigenaarGemeld { get; set; }
+    [Column("VeldEigenaarGemeld")]
+    public bool FieldOwnerNotified { get; set; }
 
     // Section 2 - Meteorologische Informatie
     public double? SurfaceWindSpeedKt { get; set; }
     public int? SurfaceWindDirectionDeg { get; set; }
     public string? Metar { get; set; }
     public string? Taf { get; set; }
-    public string? WindPerHoogte { get; set; }
-    public string? Neerslag { get; set; }
-    public double? TemperatuurC { get; set; }
-    public double? DauwpuntC { get; set; }
+    [Column("WindPerHoogte")]
+    public string? WindByAltitude { get; set; }
+    [Column("Neerslag")]
+    public string? Precipitation { get; set; }
+    [Column("TemperatuurC")]
+    public double? TemperatureC { get; set; }
+    [Column("DauwpuntC")]
+    public double? DewPointC { get; set; }
     public double? QnhHpa { get; set; }
-    public double? ZichtbaarheidKm { get; set; }
+    [Column("ZichtbaarheidKm")]
+    public double? VisibilityKm { get; set; }
     public double? CapeJkg { get; set; }
 
     // Section 3 - Luchtruim en NOTAMs
     public string NotamsGecontroleerd { get; set; } = "NEE";
-    public string? Luchtruimstructuur { get; set; }
-    public string? Beperkingen { get; set; }
-    public string? Obstakels { get; set; }
+    [Column("Luchtruimstructuur")]
+    public string? AirspaceStructure { get; set; }
+    [Column("Beperkingen")]
+    public string? Restrictions { get; set; }
+    [Column("Obstakels")]
+    public string? Obstacles { get; set; }
 
     // Section 4 - Veiligheid en Communicatie
-    public string EhboEnBlusser { get; set; } = "NEE";
-    public string PassagierslijstIngevuld { get; set; } = "NEE";
-    public string VluchtplanIngediend { get; set; } = "NVT";
+    [Column("EhboEnBlusser")]
+    public string FirstAidAndExtinguisher { get; set; } = "NEE";
+    [Column("PassagierslijstIngevuld")]
+    public string PassengerListFilled { get; set; } = "NEE";
+    [Column("VluchtplanIngediend")]
+    public string FlightPlanFiled { get; set; } = "NVT";
 
     // Section 5 - Technische Controle
-    public bool BranderGetest { get; set; }
-    public bool GasflaconsGecontroleerd { get; set; }
-    public bool BallonVisueel { get; set; }
-    public bool VerankeringenGecontroleerd { get; set; }
-    public bool InstrumentenWerkend { get; set; }
+    [Column("BranderGetest")]
+    public bool BurnerTested { get; set; }
+    [Column("GasflaconsGecontroleerd")]
+    public bool GasCylindersChecked { get; set; }
+    [Column("BallonVisueel")]
+    public bool BalloonVisual { get; set; }
+    [Column("VerankeringenGecontroleerd")]
+    public bool MooringsChecked { get; set; }
+    [Column("InstrumentenWerkend")]
+    public bool InstrumentsWorking { get; set; }
 
     // Section 6 - Pax Briefing
     public string? PaxBriefing { get; set; }
@@ -60,8 +81,9 @@ public class FlightPreparation
     public double? TotaalLiftKg { get; set; }
     public string? LoadNotes { get; set; }
 
-    // Section 8 - Traject
-    public string? Traject { get; set; }
+    // Section 8 - Route
+    [Column("Traject")]
+    public string? Route { get; set; }
     public string? TrajectorySimulationJson { get; set; }
 
     // Mark as flown
@@ -82,8 +104,9 @@ public class FlightPreparation
     // Shares (users this prep has been shared with)
     public ICollection<FlightPreparationShare> Shares { get; set; } = new List<FlightPreparationShare>();
 
-    // Section 9 - Ballonbulletin
-    public string? Ballonbulletin { get; set; }
+    // Section 9 - BalloonBulletin
+    [Column("Ballonbulletin")]
+    public string? BalloonBulletin { get; set; }
 
     // Section 10 - OFP (Operational Flight Plan)
     // Snapshotted from ApplicationUser on new flight (fp.Id == 0)
@@ -127,14 +150,14 @@ public class FlightPreparation
     {
         get
         {
-            var hasData = SurfaceWindSpeedKt.HasValue || ZichtbaarheidKm.HasValue || CapeJkg.HasValue;
+            var hasData = SurfaceWindSpeedKt.HasValue || VisibilityKm.HasValue || CapeJkg.HasValue;
             if (!hasData)
             {
                 return "unknown";
             }
 
-            var red = SurfaceWindSpeedKt >= 15 || ZichtbaarheidKm < 3 || CapeJkg > 500;
-            var yellow = SurfaceWindSpeedKt >= 10 || ZichtbaarheidKm < 5 || CapeJkg > 300;
+            var red = SurfaceWindSpeedKt >= 15 || VisibilityKm < 3 || CapeJkg > 500;
+            var yellow = SurfaceWindSpeedKt >= 10 || VisibilityKm < 5 || CapeJkg > 300;
             return red ? "red" : yellow ? "yellow" : "green";
         }
     }

--- a/src/FlightPrep.Domain/Models/FlightPreparationSummary.cs
+++ b/src/FlightPrep.Domain/Models/FlightPreparationSummary.cs
@@ -7,14 +7,14 @@ namespace FlightPrep.Domain.Models;
 /// </summary>
 public record FlightPreparationSummary(
     int Id,
-    DateOnly Datum,
-    TimeOnly Tijdstip,
+    DateOnly Date,
+    TimeOnly Time,
     bool IsFlown,
     string? BalloonRegistration,
     string? PilotName,
     string? LocationName,
     double? SurfaceWindSpeedKt,
-    double? ZichtbaarheidKm,
+    double? VisibilityKm,
     double? CapeJkg,
     string? CreatedByUserId)
 {

--- a/src/FlightPrep.Domain/Services/LiftCalculator.cs
+++ b/src/FlightPrep.Domain/Services/LiftCalculator.cs
@@ -12,7 +12,7 @@ public static class LiftCalculator
 
     /// <param name="A">Maximum planned flight altitude AMSL in metres</param>
     /// <param name="Eg">Take-off site elevation AMSL in metres</param>
-    /// <param name="Tg">Ambient temperature at take-off site in °C (= FlightPreparation.TemperatuurC)</param>
+    /// <param name="Tg">Ambient temperature at take-off site in °C (= FlightPreparation.TemperatureC)</param>
     /// <param name="Ti">Average internal envelope temperature in °C — capped at 100°C</param>
     /// <param name="V">Envelope volume in m³</param>
     public static LiftResult Calculate(double A, double Eg, double Tg, double Ti, double V)

--- a/src/FlightPrep.Infrastructure.Tests/FlightPreparationServiceOwnershipTests.cs
+++ b/src/FlightPrep.Infrastructure.Tests/FlightPreparationServiceOwnershipTests.cs
@@ -46,9 +46,9 @@ public class FlightPreparationServiceOwnershipTests
     {
         await using var db = await factory.CreateDbContextAsync();
 
-        var fp1 = new FlightPreparation { Datum = new DateOnly(2025, 1, 1), Tijdstip = TimeOnly.MinValue, CreatedByUserId = "user1" };
-        var fp2 = new FlightPreparation { Datum = new DateOnly(2025, 2, 1), Tijdstip = TimeOnly.MinValue, CreatedByUserId = "user2" };
-        var fp3 = new FlightPreparation { Datum = new DateOnly(2025, 3, 1), Tijdstip = TimeOnly.MinValue, CreatedByUserId = null };
+        var fp1 = new FlightPreparation { Date = new DateOnly(2025, 1, 1), Time = TimeOnly.MinValue, CreatedByUserId = "user1" };
+        var fp2 = new FlightPreparation { Date = new DateOnly(2025, 2, 1), Time = TimeOnly.MinValue, CreatedByUserId = "user2" };
+        var fp3 = new FlightPreparation { Date = new DateOnly(2025, 3, 1), Time = TimeOnly.MinValue, CreatedByUserId = null };
 
         db.FlightPreparations.AddRange(fp1, fp2, fp3);
         await db.SaveChangesAsync();

--- a/src/FlightPrep.Infrastructure.Tests/FlightPreparationServiceTests.cs
+++ b/src/FlightPrep.Infrastructure.Tests/FlightPreparationServiceTests.cs
@@ -51,8 +51,8 @@ public class FlightPreparationServiceTests
         Pilot? pilot = null,
         Location? location = null) => new()
     {
-        Datum = DateOnly.FromDateTime(DateTime.Today),
-        Tijdstip = TimeOnly.FromDateTime(DateTime.Now),
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Time = TimeOnly.FromDateTime(DateTime.Now),
         Balloon = balloon,
         Pilot = pilot,
         Location = location,
@@ -310,7 +310,7 @@ public class FlightPreparationServiceTests
         fp2.IsFlown = false;
         // 1 flight from the past year, not flown
         var fp3 = SeedFlight();
-        fp3.Datum = new DateOnly(2020, 1, 1);
+        fp3.Date = new DateOnly(2020, 1, 1);
         fp3.IsFlown = false;
 
         await sut.SaveAsync(fp1);
@@ -336,11 +336,11 @@ public class FlightPreparationServiceTests
         var sut = BuildSut(factory);
 
         var oldest = SeedFlight();
-        oldest.Datum = new DateOnly(2024, 1, 1);
+        oldest.Date = new DateOnly(2024, 1, 1);
         var middle = SeedFlight();
-        middle.Datum = new DateOnly(2024, 6, 1);
+        middle.Date = new DateOnly(2024, 6, 1);
         var newest = SeedFlight();
-        newest.Datum = new DateOnly(2025, 1, 1);
+        newest.Date = new DateOnly(2025, 1, 1);
 
         await sut.SaveAsync(oldest);
         await sut.SaveAsync(middle);
@@ -351,8 +351,8 @@ public class FlightPreparationServiceTests
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Equal(new DateOnly(2025, 1, 1), result[0].Datum);
-        Assert.Equal(new DateOnly(2024, 6, 1), result[1].Datum);
+        Assert.Equal(new DateOnly(2025, 1, 1), result[0].Date);
+        Assert.Equal(new DateOnly(2024, 6, 1), result[1].Date);
     }
 
     [Fact]
@@ -504,11 +504,11 @@ public class FlightPreparationServiceTests
         var sut = BuildSut(factory);
 
         var fp1 = SeedFlight();
-        fp1.Datum = new DateOnly(2025, 3, 1);
+        fp1.Date = new DateOnly(2025, 3, 1);
         var fp2 = SeedFlight();
-        fp2.Datum = new DateOnly(2024, 1, 15);
+        fp2.Date = new DateOnly(2024, 1, 15);
         var fp3 = SeedFlight();
-        fp3.Datum = new DateOnly(2025, 1, 10);
+        fp3.Date = new DateOnly(2025, 1, 10);
 
         await sut.SaveAsync(fp1);
         await sut.SaveAsync(fp2);
@@ -519,7 +519,7 @@ public class FlightPreparationServiceTests
 
         // Assert — ascending order
         Assert.Equal(3, result.Count);
-        Assert.True(result[0].Datum <= result[1].Datum);
-        Assert.True(result[1].Datum <= result[2].Datum);
+        Assert.True(result[0].Date <= result[1].Date);
+        Assert.True(result[1].Date <= result[2].Date);
     }
 }

--- a/src/FlightPrep.Infrastructure.Tests/FlightPreparationSharingTests.cs
+++ b/src/FlightPrep.Infrastructure.Tests/FlightPreparationSharingTests.cs
@@ -48,8 +48,8 @@ public class FlightPreparationSharingTests
         await using var db = await factory.CreateDbContextAsync();
         var fp = new FlightPreparation
         {
-            Datum = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = TimeOnly.MinValue,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.MinValue,
             CreatedByUserId = ownerId
         };
         db.FlightPreparations.Add(fp);

--- a/src/FlightPrep.Infrastructure/Services/PdfService.cs
+++ b/src/FlightPrep.Infrastructure/Services/PdfService.cs
@@ -28,7 +28,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
         var loc = fp.Location;
         if (loc?.Latitude.HasValue == true && loc.Longitude.HasValue)
         {
-            sunriseSunset = sunriseSvc.Calculate(fp.Datum, loc.Latitude!.Value, loc.Longitude!.Value);
+            sunriseSunset = sunriseSvc.Calculate(fp.Date, loc.Latitude!.Value, loc.Longitude!.Value);
         }
 
         var assessment = await assessmentSvc.ComputeAsync(fp, userId);
@@ -49,7 +49,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                         col.Item().AlignCenter().Text("Vaartvoorbereiding Ballonvaart")
                             .Bold().FontSize(18).FontColor(PrimaryColor);
                         col.Item().AlignCenter().Text(
-                                $"{fp.Datum:dd/MM/yyyy}  –  {fp.Tijdstip:HH:mm} LT" +
+                                $"{fp.Date:dd/MM/yyyy}  –  {fp.Time:HH:mm} LT" +
                                 (fp.Balloon != null ? $"  |  {fp.Balloon.Registration} ({fp.Balloon.Type})" : "") +
                                 (fp.Pilot != null ? $"  |  {fp.Pilot.Name}" : ""))
                             .FontSize(10);
@@ -68,15 +68,15 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                     // Build Section 1 rows including optional sunrise/sunset
                     var sec1Rows = new List<(string, string)>
                     {
-                        ("Datum", fp.Datum.ToString("dd/MM/yyyy")),
-                        ("Tijdstip (LT)", fp.Tijdstip.ToString("HH:mm")),
+                        ("Datum", fp.Date.ToString("dd/MM/yyyy")),
+                        ("Tijdstip (LT)", fp.Time.ToString("HH:mm")),
                         ("Ballon",
                             fp.Balloon != null
                                 ? $"{fp.Balloon.Registration} – {fp.Balloon.Type} ({(fp.Balloon.VolumeM3.HasValue ? $"{fp.Balloon.VolumeM3:F0} m³" : "–")})"
                                 : "–"),
                         ("Piloot / PIC", fp.Pilot?.Name ?? "–"),
                         ("Locatie", fp.Location?.Name ?? "–"),
-                        ("Veld eigenaar gemeld", fp.VeldEigenaarGemeld ? "Ja" : "Nee / NVT")
+                        ("Veld eigenaar gemeld", fp.FieldOwnerNotified ? "Ja" : "Nee / NVT")
                     };
                     if (sunriseSunset.HasValue)
                     {
@@ -91,14 +91,14 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                     {
                         ("METAR", fp.Metar ?? "–"),
                         ("TAF", fp.Taf ?? "–"),
-                        ("Wind per hoogte", fp.WindPerHoogte ?? "–"),
-                        ("Neerslag / bewolking", fp.Neerslag ?? "–"),
+                        ("Wind per hoogte", fp.WindByAltitude ?? "–"),
+                        ("Neerslag / bewolking", fp.Precipitation ?? "–"),
                         ("Windrichting oppervlak", fp.SurfaceWindDirectionDeg.HasValue ? $"{fp.SurfaceWindDirectionDeg}°" : "–"),
                         ("Windsnelheid oppervlak", fp.SurfaceWindSpeedKt.HasValue ? $"{fp.SurfaceWindSpeedKt} kt" : "–"),
-                        ("Temperatuur", fp.TemperatuurC.HasValue ? $"{fp.TemperatuurC}°C" : "–"),
-                        ("Dauwpunt", fp.DauwpuntC.HasValue ? $"{fp.DauwpuntC}°C" : "–"),
+                        ("Temperatuur", fp.TemperatureC.HasValue ? $"{fp.TemperatureC}°C" : "–"),
+                        ("Dauwpunt", fp.DewPointC.HasValue ? $"{fp.DewPointC}°C" : "–"),
                         ("QNH", fp.QnhHpa.HasValue ? $"{fp.QnhHpa} hPa" : "–"),
-                        ("Zichtbaarheid", fp.ZichtbaarheidKm.HasValue ? $"{fp.ZichtbaarheidKm} km" : "–"),
+                        ("Zichtbaarheid", fp.VisibilityKm.HasValue ? $"{fp.VisibilityKm} km" : "–"),
                         ("CAPE", fp.CapeJkg.HasValue ? $"{fp.CapeJkg} J/kg" : "–")
                     };
                     AddSection(col, "2. Meteorologische Informatie", sec2Rows.ToArray());
@@ -139,15 +139,15 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
 
                     AddSection(col, "3. Luchtruim en NOTAMs", [
                         ("NOTAMs gecontroleerd", fp.NotamsGecontroleerd),
-                        ("Luchtruimstructuur", fp.Luchtruimstructuur ?? "–"),
-                        ("Beperkingen / gesloten zones", fp.Beperkingen ?? "–"),
-                        ("Obstakels", fp.Obstakels ?? "–")
+                        ("Luchtruimstructuur", fp.AirspaceStructure ?? "–"),
+                        ("Beperkingen / gesloten zones", fp.Restrictions ?? "–"),
+                        ("Obstakels", fp.Obstacles ?? "–")
                     ]);
 
                     AddSection(col, "4. Veiligheid en Communicatie", [
-                        ("EHBO-kit en vuurblusser", fp.EhboEnBlusser),
-                        ("Passagierslijst ingevuld", fp.PassagierslijstIngevuld),
-                        ("Vluchtplan ingediend", fp.VluchtplanIngediend)
+                        ("EHBO-kit en vuurblusser", fp.FirstAidAndExtinguisher),
+                        ("Passagierslijst ingevuld", fp.PassengerListFilled),
+                        ("Vluchtplan ingediend", fp.FlightPlanFiled)
                     ]);
 
                     // Section 5 - Technische Controle with checkboxes
@@ -155,9 +155,9 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                         .Text("5. Technische Controle").Bold().FontColor(Colors.White).FontSize(10);
                     var checks = new[]
                     {
-                        (fp.BranderGetest, "Brander getest"), (fp.GasflaconsGecontroleerd, "Gasflessen gevuld & gecontroleerd"),
-                        (fp.BallonVisueel, "Ballon en mand visueel geïnspecteerd"), (fp.VerankeringenGecontroleerd, "Verankeringen en touwen gecontroleerd"),
-                        (fp.InstrumentenWerkend, "Instrumenten werkend")
+                        (fp.BurnerTested, "Brander getest"), (fp.GasCylindersChecked, "Gasflessen gevuld & gecontroleerd"),
+                        (fp.BalloonVisual, "Ballon en mand visueel geïnspecteerd"), (fp.MooringsChecked, "Verankeringen en touwen gecontroleerd"),
+                        (fp.InstrumentsWorking, "Instrumenten werkend")
                     };
                     var alt5 = false;
                     foreach (var (@checked, label) in checks)
@@ -227,11 +227,11 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                     if (fp.Balloon?.VolumeM3.HasValue == true &&
                         fp.Balloon?.InternalEnvelopeTempC.HasValue == true &&
                         fp.Location?.ElevationM.HasValue == true &&
-                        fp is { TemperatuurC: not null, MaxAltitudeFt: not null })
+                        fp is { TemperatureC: not null, MaxAltitudeFt: not null })
                     {
                         var A = fp.MaxAltitudeFt.Value * 0.3048;
                         var Eg = fp.Location.ElevationM.Value;
-                        var Tg = fp.TemperatuurC.Value;
+                        var Tg = fp.TemperatureC.Value;
                         var Ti = fp.Balloon.InternalEnvelopeTempC.Value;
                         var V = fp.Balloon.VolumeM3.Value;
                         var lr = LiftCalculator.Calculate(A, Eg, Tg, Ti, V);
@@ -252,7 +252,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                     }
 
                     AddSection(col, "8. Traject", [
-                        ("Trajectnotities", fp.Traject ?? "–")
+                        ("Trajectnotities", fp.Route ?? "–")
                     ]);
 
                     // Simulated trajectories summary
@@ -315,7 +315,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                     col.Item().PaddingTop(6).ShowEntire().Background(PrimaryColor).Padding(4)
                         .Text("9. Ballonbulletin").Bold().FontColor(Colors.White).FontSize(10);
                     col.Item().ShowEntire().Background(Colors.White).Padding(4)
-                        .Text(fp.Ballonbulletin ?? "–").FontFamily("Courier New").FontSize(7.5f);
+                        .Text(fp.BalloonBulletin ?? "–").FontFamily("Courier New").FontSize(7.5f);
 
                     if (fp.IsFlown)
                     {
@@ -514,7 +514,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                             row.RelativeItem(2).Padding(3).Column(c =>
                             {
                                 c.Item().Text("DATE").Bold().FontSize(7).FontColor(Colors.Grey.Darken1);
-                                c.Item().Text(fp.Datum.ToString("ddd d-MM-yy")).FontSize(8);
+                                c.Item().Text(fp.Date.ToString("ddd d-MM-yy")).FontSize(8);
                             });
                         });
                         // Row 2: PIC | TAKEOFF LOCATION | LANDING LOCATION | TAKEOFF TIME / LANDING TIME
@@ -538,7 +538,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                             row.RelativeItem(2).Padding(3).Column(c =>
                             {
                                 c.Item().Text("TAKEOFF / LANDING").Bold().FontSize(7).FontColor(Colors.Grey.Darken1);
-                                var takeoff = fp.Tijdstip.ToString("HH:mm");
+                                var takeoff = fp.Time.ToString("HH:mm");
                                 var landing = fp.PlannedLandingTime?.ToString("HH:mm") ?? "—";
                                 c.Item().Text($"{takeoff} / {landing}").FontSize(8);
                             });
@@ -633,19 +633,19 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                                 wTable.Cell().Element(WValueCell).Text("Meteoblue").FontSize(8);
 
                                 wTable.Cell().Element(WLabelCell).Text("DATE").Bold().FontSize(7);
-                                wTable.Cell().Element(WValueCell).Text(fp.Datum.ToString("d-MM-yyyy")).FontSize(8);
+                                wTable.Cell().Element(WValueCell).Text(fp.Date.ToString("d-MM-yyyy")).FontSize(8);
 
                                 wTable.Cell().Element(WLabelCell).Text("VISIBILITY").Bold().FontSize(7);
                                 wTable.Cell().Element(WValueCell)
-                                    .Text(fp.ZichtbaarheidKm.HasValue ? $"{fp.ZichtbaarheidKm} km" : "—").FontSize(8);
+                                    .Text(fp.VisibilityKm.HasValue ? $"{fp.VisibilityKm} km" : "—").FontSize(8);
 
                                 wTable.Cell().Element(WLabelCell).Text("CLOUDS").Bold().FontSize(7);
                                 wTable.Cell().Element(WValueCell)
-                                    .Text(!string.IsNullOrWhiteSpace(fp.Neerslag) ? fp.Neerslag : "—").FontSize(8);
+                                    .Text(!string.IsNullOrWhiteSpace(fp.Precipitation) ? fp.Precipitation : "—").FontSize(8);
 
                                 wTable.Cell().Element(WLabelCell).Text("TEMP").Bold().FontSize(7);
                                 wTable.Cell().Element(WValueCell)
-                                    .Text(fp.TemperatuurC.HasValue ? $"{fp.TemperatuurC} °C" : "—").FontSize(8);
+                                    .Text(fp.TemperatureC.HasValue ? $"{fp.TemperatureC} °C" : "—").FontSize(8);
 
                                 wTable.Cell().Element(WLabelCell).Text("QNH").Bold().FontSize(7);
                                 wTable.Cell().Element(WValueCell)
@@ -687,7 +687,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                             string plannedTime;
                             if (fp.PlannedLandingTime.HasValue)
                             {
-                                var rawMinutes = (fp.PlannedLandingTime.Value.ToTimeSpan() - fp.Tijdstip.ToTimeSpan()).TotalMinutes;
+                                var rawMinutes = (fp.PlannedLandingTime.Value.ToTimeSpan() - fp.Time.ToTimeSpan()).TotalMinutes;
                                 // Handle past-midnight flights (negative result)
                                 if (rawMinutes < 0) rawMinutes += 24 * 60;
                                 var durationMinutes = (int)rawMinutes;
@@ -744,7 +744,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
 
                                 lTable.Cell().Element(LLabelCell).Text("TAKEOFF TEMP").Bold().FontSize(7);
                                 lTable.Cell().Element(LValueCell)
-                                    .Text(fp.TemperatuurC.HasValue ? $"{fp.TemperatuurC} °C" : "—").FontSize(8);
+                                    .Text(fp.TemperatureC.HasValue ? $"{fp.TemperatureC} °C" : "—").FontSize(8);
 
                                 lTable.Cell().Element(LLabelCell).Text("QNH").Bold().FontSize(7);
                                 lTable.Cell().Element(LValueCell)
@@ -905,7 +905,7 @@ public class PdfService(ISunriseService sunriseSvc, ITrajectoryMapService mapSvc
                         dTable.Cell().ColumnSpan(2).Element(DValueCell)
                             .Text(BlankBool(fp.VisibleDefects)).FontSize(8);
                         dTable.Cell().ColumnSpan(2).Element(DValueCell)
-                            .Text(fp.IsFlown ? fp.Datum.ToString("d-MM-yyyy") : "________________").FontSize(8);
+                            .Text(fp.IsFlown ? fp.Date.ToString("d-MM-yyyy") : "________________").FontSize(8);
 
                         // Row 3 — SIGNATURE label row
                         dTable.Cell().ColumnSpan(5).Element(DLabelCell)

--- a/src/FlightPrep.Tests/FlightAssessmentServiceTests.cs
+++ b/src/FlightPrep.Tests/FlightAssessmentServiceTests.cs
@@ -211,7 +211,7 @@ public class FlightAssessmentServiceTests
     {
         // Arrange
         var sut = BuildSutWithRealGoNoGo();
-        var fp = new FlightPreparation { SurfaceWindSpeedKt = 5, ZichtbaarheidKm = 15, CapeJkg = 50, TotaalLiftKg = 1000 };
+        var fp = new FlightPreparation { SurfaceWindSpeedKt = 5, VisibilityKm = 15, CapeJkg = 50, TotaalLiftKg = 1000 };
 
         // Act
         var result = sut.Compute(fp, DefaultSettings());
@@ -328,7 +328,7 @@ public class FlightAssessmentServiceTests
             EnvelopeWeightKg = 100,
             Pilot = new Pilot { WeightKg = 80 },
             SurfaceWindSpeedKt = 5,
-            ZichtbaarheidKm = 20,
+            VisibilityKm = 20,
             CapeJkg = 50,
             TotaalLiftKg = 1000
         };

--- a/src/FlightPrep.Tests/FlightPreparationServiceTests.cs
+++ b/src/FlightPrep.Tests/FlightPreparationServiceTests.cs
@@ -47,8 +47,8 @@ public class FlightPreparationServiceTests
         Pilot? pilot = null,
         Location? location = null) => new()
     {
-        Datum = DateOnly.FromDateTime(DateTime.Today),
-        Tijdstip = TimeOnly.FromDateTime(DateTime.Now),
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Time = TimeOnly.FromDateTime(DateTime.Now),
         Balloon = balloon,
         Pilot = pilot,
         Location = location,
@@ -530,7 +530,7 @@ public class FlightPreparationServiceTests
         var fp2 = SeedFlight();
         fp2.IsFlown = false;
         var fp3 = SeedFlight();
-        fp3.Datum = new DateOnly(2020, 1, 1);
+        fp3.Date = new DateOnly(2020, 1, 1);
         fp3.IsFlown = false;
 
         await sut.SaveAsync(fp1);
@@ -556,11 +556,11 @@ public class FlightPreparationServiceTests
         var sut = BuildSut(factory);
 
         var oldest = SeedFlight();
-        oldest.Datum = new DateOnly(2024, 1, 1);
+        oldest.Date = new DateOnly(2024, 1, 1);
         var middle = SeedFlight();
-        middle.Datum = new DateOnly(2024, 6, 1);
+        middle.Date = new DateOnly(2024, 6, 1);
         var newest = SeedFlight();
-        newest.Datum = new DateOnly(2025, 1, 1);
+        newest.Date = new DateOnly(2025, 1, 1);
 
         await sut.SaveAsync(oldest);
         await sut.SaveAsync(middle);
@@ -571,8 +571,8 @@ public class FlightPreparationServiceTests
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Equal(new DateOnly(2025, 1, 1), result[0].Datum);
-        Assert.Equal(new DateOnly(2024, 6, 1), result[1].Datum);
+        Assert.Equal(new DateOnly(2025, 1, 1), result[0].Date);
+        Assert.Equal(new DateOnly(2024, 6, 1), result[1].Date);
     }
 
     [Fact]
@@ -609,11 +609,11 @@ public class FlightPreparationServiceTests
         var sut = BuildSut(factory);
 
         var fp1 = SeedFlight();
-        fp1.Datum = new DateOnly(2025, 3, 1);
+        fp1.Date = new DateOnly(2025, 3, 1);
         var fp2 = SeedFlight();
-        fp2.Datum = new DateOnly(2024, 1, 15);
+        fp2.Date = new DateOnly(2024, 1, 15);
         var fp3 = SeedFlight();
-        fp3.Datum = new DateOnly(2025, 1, 10);
+        fp3.Date = new DateOnly(2025, 1, 10);
 
         await sut.SaveAsync(fp1);
         await sut.SaveAsync(fp2);
@@ -624,8 +624,8 @@ public class FlightPreparationServiceTests
 
         // Assert — ascending order
         Assert.Equal(3, result.Count);
-        Assert.True(result[0].Datum <= result[1].Datum);
-        Assert.True(result[1].Datum <= result[2].Datum);
+        Assert.True(result[0].Date <= result[1].Date);
+        Assert.True(result[1].Date <= result[2].Date);
     }
 
     [Fact]
@@ -846,8 +846,8 @@ public class FlightPreparationServiceTests
         bool isFlown = false,
         int dateDeltaDays = 0) => new()
     {
-        Datum           = DateOnly.FromDateTime(DateTime.Today.AddDays(dateDeltaDays)),
-        Tijdstip        = TimeOnly.MinValue,
+        Date = DateOnly.FromDateTime(DateTime.Today.AddDays(dateDeltaDays)),
+        Time = TimeOnly.MinValue,
         CreatedByUserId = userId,
         IsFlown         = isFlown,
     };
@@ -924,8 +924,8 @@ public class FlightPreparationServiceTests
 
         // Assert — dates descending
         for (var i = 1; i < items.Count; i++)
-            Assert.True(items[i].Datum <= items[i - 1].Datum,
-                $"Expected descending dates but got {items[i - 1].Datum} then {items[i].Datum}");
+            Assert.True(items[i].Date <= items[i - 1].Date,
+                $"Expected descending dates but got {items[i - 1].Date} then {items[i].Date}");
     }
 
     [Fact]
@@ -946,8 +946,8 @@ public class FlightPreparationServiceTests
 
         // Assert — dates ascending
         for (var i = 1; i < items.Count; i++)
-            Assert.True(items[i].Datum >= items[i - 1].Datum,
-                $"Expected ascending dates but got {items[i - 1].Datum} then {items[i].Datum}");
+            Assert.True(items[i].Date >= items[i - 1].Date,
+                $"Expected ascending dates but got {items[i - 1].Date} then {items[i].Date}");
     }
 
     [Fact]
@@ -1424,8 +1424,8 @@ public class FlightPreparationServiceTests
         await using var db = await factory.CreateDbContextAsync();
         db.FlightPreparations.Add(new FlightPreparation
         {
-            Datum             = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip          = TimeOnly.MinValue,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.MinValue,
             CreatedByUserId   = null   // no owner
         });
         await db.SaveChangesAsync();

--- a/src/FlightPrep.Tests/FlightPreparationSharingTests.cs
+++ b/src/FlightPrep.Tests/FlightPreparationSharingTests.cs
@@ -47,8 +47,8 @@ public class FlightPreparationSharingTests
         await using var db = await factory.CreateDbContextAsync();
         var fp = new FlightPreparation
         {
-            Datum = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = TimeOnly.MinValue,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.MinValue,
             CreatedByUserId = ownerId
         };
         db.FlightPreparations.Add(fp);

--- a/src/FlightPrep.Tests/FlightPreparationTests.cs
+++ b/src/FlightPrep.Tests/FlightPreparationTests.cs
@@ -115,7 +115,7 @@ public class FlightPreparationTests
     [Obsolete("Obsolete")]
     public void GoNoGo_VisibilityBelowRedThreshold_ReturnsRed()
     {
-        var fp = new FlightPreparation { ZichtbaarheidKm = 2.5 };
+        var fp = new FlightPreparation { VisibilityKm = 2.5 };
 
         Assert.Equal("red", fp.GoNoGo);
     }
@@ -142,7 +142,7 @@ public class FlightPreparationTests
     [Obsolete("Obsolete")]
     public void GoNoGo_VisibilityBelowYellowThreshold_ReturnsYellow()
     {
-        var fp = new FlightPreparation { ZichtbaarheidKm = 4 };
+        var fp = new FlightPreparation { VisibilityKm = 4 };
 
         Assert.Equal("yellow", fp.GoNoGo);
     }
@@ -160,7 +160,7 @@ public class FlightPreparationTests
     [Obsolete("Obsolete")]
     public void GoNoGo_AllConditionsGood_ReturnsGreen()
     {
-        var fp = new FlightPreparation { SurfaceWindSpeedKt = 5, ZichtbaarheidKm = 10, CapeJkg = 100 };
+        var fp = new FlightPreparation { SurfaceWindSpeedKt = 5, VisibilityKm = 10, CapeJkg = 100 };
 
         Assert.Equal("green", fp.GoNoGo);
     }

--- a/src/FlightPrep.Tests/GoNoGoServiceIssueCoverageTests.cs
+++ b/src/FlightPrep.Tests/GoNoGoServiceIssueCoverageTests.cs
@@ -28,7 +28,7 @@ public class GoNoGoServiceIssueCoverageTests
 
     private static FlightPreparation FpWith(
         double? wind = null, double? vis = null, double? cape = null) =>
-        new() { SurfaceWindSpeedKt = wind, ZichtbaarheidKm = vis, CapeJkg = cape };
+        new() { SurfaceWindSpeedKt = wind, VisibilityKm = vis, CapeJkg = cape };
 
     // ── Custom threshold: wind red ────────────────────────────────────────────
 
@@ -200,7 +200,7 @@ public class GoNoGoServiceIssueCoverageTests
 
         // Act — both overloads
         var fromFp  = sut.Compute(fp, settings);
-        var fromRaw = sut.Compute(fp.SurfaceWindSpeedKt, fp.ZichtbaarheidKm, fp.CapeJkg, settings);
+        var fromRaw = sut.Compute(fp.SurfaceWindSpeedKt, fp.VisibilityKm, fp.CapeJkg, settings);
 
         // Assert — both overloads agree with each other and with the expected value
         Assert.Equal(expectedResult, fromFp);

--- a/src/FlightPrep.Tests/GoNoGoServiceTests.cs
+++ b/src/FlightPrep.Tests/GoNoGoServiceTests.cs
@@ -8,7 +8,7 @@ public class GoNoGoServiceComputeTests
     private static readonly GoNoGoSettings DefaultSettings = new();
 
     private static FlightPreparation FpWith(
-        double? wind = null, double? vis = null, double? cape = null) => new() { SurfaceWindSpeedKt = wind, ZichtbaarheidKm = vis, CapeJkg = cape };
+        double? wind = null, double? vis = null, double? cape = null) => new() { SurfaceWindSpeedKt = wind, VisibilityKm = vis, CapeJkg = cape };
 
     [Fact]
     public void Compute_NoMeteoData_ReturnsUnknown()

--- a/src/FlightPrep.Tests/ModelPropertyTests.cs
+++ b/src/FlightPrep.Tests/ModelPropertyTests.cs
@@ -206,57 +206,57 @@ public class ModelPropertyTests
         var fp = new FlightPreparation
         {
             Id = 1,
-            Datum = new DateOnly(2026, 3, 26),
-            Tijdstip = new TimeOnly(9, 0),
+            Date = new DateOnly(2026, 3, 26),
+            Time = new TimeOnly(9, 0),
             BalloonId = 2,
             PilotId = 3,
             LocationId = 4,
-            VeldEigenaarGemeld = true,
+            FieldOwnerNotified = true,
             SurfaceWindSpeedKt = 8,
             SurfaceWindDirectionDeg = 220,
             Metar = "EBBR 261020Z",
             Taf = "TAF EBBR",
-            WindPerHoogte = "220/08",
-            Neerslag = "NONE",
-            TemperatuurC = 15.0,
-            DauwpuntC = 8.0,
+            WindByAltitude = "220/08",
+            Precipitation = "NONE",
+            TemperatureC = 15.0,
+            DewPointC = 8.0,
             QnhHpa = 1013.25,
-            ZichtbaarheidKm = 15,
+            VisibilityKm = 15,
             CapeJkg = 50,
             NotamsGecontroleerd = "JA",
-            Luchtruimstructuur = "CTR Brussel",
-            Beperkingen = "Geen",
-            Obstakels = "Windmolens N",
-            EhboEnBlusser = "JA",
-            PassagierslijstIngevuld = "JA",
-            VluchtplanIngediend = "JA",
-            BranderGetest = true,
-            GasflaconsGecontroleerd = true,
-            BallonVisueel = true,
-            VerankeringenGecontroleerd = true,
-            InstrumentenWerkend = true,
+            AirspaceStructure = "CTR Brussel",
+            Restrictions = "Geen",
+            Obstacles = "Windmolens N",
+            FirstAidAndExtinguisher = "JA",
+            PassengerListFilled = "JA",
+            FlightPlanFiled = "JA",
+            BurnerTested = true,
+            GasCylindersChecked = true,
+            BalloonVisual = true,
+            MooringsChecked = true,
+            InstrumentsWorking = true,
             PaxBriefing = "<p>Welkom</p>",
             EnvelopeWeightKg = 200,
             MaxAltitudeFt = 3000,
             LiftUnits = 600,
             TotaalLiftKg = 600,
             LoadNotes = "OK",
-            Traject = "Noord",
+            Route = "Noord",
             IsFlown = true,
             ActualLandingNotes = "Veldje",
             ActualFlightDurationMinutes = 75,
             ActualRemarks = "Mooi",
             KmlTrack = "<kml/>",
-            Ballonbulletin = "Bulletin tekst"
+            BalloonBulletin = "Bulletin tekst"
         };
 
         Assert.Equal(1, fp.Id);
-        Assert.Equal(new DateOnly(2026, 3, 26), fp.Datum);
-        Assert.True(fp.VeldEigenaarGemeld);
+        Assert.Equal(new DateOnly(2026, 3, 26), fp.Date);
+        Assert.True(fp.FieldOwnerNotified);
         Assert.Equal("EBBR 261020Z", fp.Metar);
         Assert.Equal("TAF EBBR", fp.Taf);
         Assert.Equal("JA", fp.NotamsGecontroleerd);
-        Assert.True(fp.BranderGetest);
+        Assert.True(fp.BurnerTested);
         Assert.True(fp.IsFlown);
         Assert.Equal(75, fp.ActualFlightDurationMinutes);
         Assert.Equal("<kml/>", fp.KmlTrack);

--- a/src/FlightPrep.Tests/ModelPropertyTests.cs
+++ b/src/FlightPrep.Tests/ModelPropertyTests.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
 using FlightPrep.Domain.Models;
 
 namespace FlightPrep.Tests;
@@ -271,5 +273,160 @@ public class ModelPropertyTests
         Assert.Empty(fp.Passengers);
         Assert.Empty(fp.Images);
         Assert.Empty(fp.WindLevels);
+    }
+
+    // ── Column attribute preservation (Dutch → English rename, issue #34) ────
+
+    /// <summary>
+    ///     Verifies that each renamed English property still carries the original
+    ///     Dutch <see cref="ColumnAttribute"/> so EF Core maps to the unchanged
+    ///     database column and no migration is required.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(FlightPreparation.Date),                   "Datum")]
+    [InlineData(nameof(FlightPreparation.Time),                   "Tijdstip")]
+    [InlineData(nameof(FlightPreparation.Precipitation),          "Neerslag")]
+    [InlineData(nameof(FlightPreparation.TemperatureC),           "TemperatuurC")]
+    [InlineData(nameof(FlightPreparation.DewPointC),              "DauwpuntC")]
+    [InlineData(nameof(FlightPreparation.VisibilityKm),           "ZichtbaarheidKm")]
+    [InlineData(nameof(FlightPreparation.AirspaceStructure),      "Luchtruimstructuur")]
+    [InlineData(nameof(FlightPreparation.Restrictions),           "Beperkingen")]
+    [InlineData(nameof(FlightPreparation.Obstacles),              "Obstakels")]
+    [InlineData(nameof(FlightPreparation.FirstAidAndExtinguisher),"EhboEnBlusser")]
+    [InlineData(nameof(FlightPreparation.PassengerListFilled),    "PassagierslijstIngevuld")]
+    [InlineData(nameof(FlightPreparation.FlightPlanFiled),        "VluchtplanIngediend")]
+    [InlineData(nameof(FlightPreparation.BurnerTested),           "BranderGetest")]
+    [InlineData(nameof(FlightPreparation.GasCylindersChecked),    "GasflaconsGecontroleerd")]
+    [InlineData(nameof(FlightPreparation.BalloonVisual),          "BallonVisueel")]
+    [InlineData(nameof(FlightPreparation.MooringsChecked),        "VerankeringenGecontroleerd")]
+    [InlineData(nameof(FlightPreparation.InstrumentsWorking),     "InstrumentenWerkend")]
+    [InlineData(nameof(FlightPreparation.Route),                  "Traject")]
+    [InlineData(nameof(FlightPreparation.BalloonBulletin),        "Ballonbulletin")]
+    [InlineData(nameof(FlightPreparation.FieldOwnerNotified),     "VeldEigenaarGemeld")]
+    [InlineData(nameof(FlightPreparation.WindByAltitude),         "WindPerHoogte")]
+    public void FlightPreparation_RenamedProperty_HasOriginalDutchColumnAttribute(
+        string propertyName, string expectedColumnName)
+    {
+        // Arrange
+        var prop = typeof(FlightPreparation).GetProperty(propertyName,
+            BindingFlags.Public | BindingFlags.Instance);
+
+        // Act
+        var attr = prop?.GetCustomAttribute<ColumnAttribute>();
+
+        // Assert
+        Assert.NotNull(attr);
+        Assert.Equal(expectedColumnName, attr.Name);
+    }
+
+    // ── English property round-trip (all 21 renamed properties) ─────────────
+
+    [Fact]
+    public void FlightPreparation_RenamedStringProperties_RoundTrip()
+    {
+        // Arrange & Act
+        var fp = new FlightPreparation
+        {
+            Precipitation     = "RAIN",
+            AirspaceStructure = "CTR Brussel",
+            Restrictions      = "Geen",
+            Obstacles         = "Windmolens N",
+            WindByAltitude    = "220/08",
+            Route             = "Noord",
+            BalloonBulletin   = "Bulletin 2024-01",
+        };
+
+        // Assert
+        Assert.Equal("RAIN",           fp.Precipitation);
+        Assert.Equal("CTR Brussel",    fp.AirspaceStructure);
+        Assert.Equal("Geen",           fp.Restrictions);
+        Assert.Equal("Windmolens N",   fp.Obstacles);
+        Assert.Equal("220/08",         fp.WindByAltitude);
+        Assert.Equal("Noord",          fp.Route);
+        Assert.Equal("Bulletin 2024-01", fp.BalloonBulletin);
+    }
+
+    [Fact]
+    public void FlightPreparation_RenamedNumericProperties_RoundTrip()
+    {
+        // Arrange & Act
+        var fp = new FlightPreparation
+        {
+            TemperatureC = 18.5,
+            DewPointC    = 10.0,
+            VisibilityKm = 12.3,
+        };
+
+        // Assert
+        Assert.Equal(18.5, fp.TemperatureC);
+        Assert.Equal(10.0, fp.DewPointC);
+        Assert.Equal(12.3, fp.VisibilityKm);
+    }
+
+    [Fact]
+    public void FlightPreparation_RenamedBoolProperties_RoundTrip()
+    {
+        // Arrange & Act
+        var fp = new FlightPreparation
+        {
+            FieldOwnerNotified = true,
+            BurnerTested       = true,
+            GasCylindersChecked = true,
+            BalloonVisual      = true,
+            MooringsChecked    = true,
+            InstrumentsWorking = true,
+        };
+
+        // Assert
+        Assert.True(fp.FieldOwnerNotified);
+        Assert.True(fp.BurnerTested);
+        Assert.True(fp.GasCylindersChecked);
+        Assert.True(fp.BalloonVisual);
+        Assert.True(fp.MooringsChecked);
+        Assert.True(fp.InstrumentsWorking);
+    }
+
+    [Fact]
+    public void FlightPreparation_RenamedStatusProperties_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var fp = new FlightPreparation();
+
+        // Assert — defaults defined in the model must be preserved after rename
+        Assert.Equal("NEE", fp.FirstAidAndExtinguisher);
+        Assert.Equal("NEE", fp.PassengerListFilled);
+        Assert.Equal("NVT", fp.FlightPlanFiled);
+    }
+
+    [Fact]
+    public void FlightPreparation_RenamedStatusProperties_CanBeOverridden()
+    {
+        // Arrange & Act
+        var fp = new FlightPreparation
+        {
+            FirstAidAndExtinguisher = "JA",
+            PassengerListFilled     = "JA",
+            FlightPlanFiled         = "JA",
+        };
+
+        // Assert
+        Assert.Equal("JA", fp.FirstAidAndExtinguisher);
+        Assert.Equal("JA", fp.PassengerListFilled);
+        Assert.Equal("JA", fp.FlightPlanFiled);
+    }
+
+    [Fact]
+    public void FlightPreparation_RenamedDateAndTimeProperties_RoundTrip()
+    {
+        // Arrange
+        var date = new DateOnly(2025, 6, 1);
+        var time = new TimeOnly(7, 30);
+
+        // Act
+        var fp = new FlightPreparation { Date = date, Time = time };
+
+        // Assert
+        Assert.Equal(date, fp.Date);
+        Assert.Equal(time, fp.Time);
     }
 }

--- a/src/FlightPrep.Tests/PdfServiceOfpTests.cs
+++ b/src/FlightPrep.Tests/PdfServiceOfpTests.cs
@@ -28,8 +28,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum   = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
         };
 
         // Act
@@ -47,8 +47,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum            = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip         = TimeOnly.FromTimeSpan(TimeSpan.FromHours(9)),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.FromTimeSpan(TimeSpan.FromHours(9)),
             PicWeightKg      = 80,
             OFPEnvelopeWeightKg = 250,
             OFPBasketWeightKg   = 70,
@@ -74,8 +74,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = TimeOnly.FromTimeSpan(TimeSpan.FromHours(7)),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = TimeOnly.FromTimeSpan(TimeSpan.FromHours(7)),
             Balloon  = null,
             Pilot    = null,
             Location = null,
@@ -102,8 +102,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum               = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip            = new TimeOnly(10, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(10, 0),
             PlannedLandingTime  = new TimeOnly(11, 30),
         };
 
@@ -122,8 +122,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum               = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip            = new TimeOnly(23, 30),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(23, 30),
             PlannedLandingTime  = new TimeOnly(1, 15),
         };
 
@@ -141,8 +141,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum               = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip            = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             PlannedLandingTime  = null,
         };
 
@@ -163,8 +163,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                       = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                    = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             IsFlown                     = false,
             FuelConsumptionL            = 42,
             LandingLocationText         = "Leuven",
@@ -188,8 +188,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                       = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                    = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             IsFlown                     = true,
             FuelConsumptionL            = 35.5,
             LandingLocationText         = "Tienen",
@@ -216,8 +216,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                       = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                    = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             IsFlown                     = true,
             FuelConsumptionL            = null,
             LandingLocationText         = null,
@@ -242,13 +242,13 @@ public class PdfServiceOfpTests
     public async Task GenerateOfpAsync_NotFlown_AfterFlightDateIsBlank()
     {
         // Arrange – fp.IsFlown = false; the date cell uses the guard
-        //   fp.IsFlown ? fp.Datum.ToString("d-MM-yyyy") : "________________"
+        //   fp.IsFlown ? fp.Date.ToString("d-MM-yyyy") : "________________"
         // This must not throw even though the IsFlown branch is never taken.
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = new TimeOnly(10, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(10, 0),
             IsFlown  = false,
         };
 
@@ -270,8 +270,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum               = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip            = new TimeOnly(10, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(10, 0),
             IsFlown             = true,
             VisibleDefects      = true,
             VisibleDefectsNotes = "crack in basket",
@@ -295,8 +295,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum               = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip            = new TimeOnly(10, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(10, 0),
             IsFlown             = true,
             VisibleDefects      = false,
             VisibleDefectsNotes = null,
@@ -319,9 +319,9 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = new TimeOnly(9, 0),
-            Neerslag = "SCT030 BKN050",
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
+            Precipitation = "SCT030 BKN050",
         };
 
         // Act
@@ -339,9 +339,9 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = new TimeOnly(9, 0),
-            Neerslag = null,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
+            Precipitation = null,
         };
 
         // Act
@@ -359,9 +359,9 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = new TimeOnly(9, 0),
-            Neerslag = string.Empty,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
+            Precipitation = string.Empty,
         };
 
         // Act
@@ -379,9 +379,9 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip = new TimeOnly(9, 0),
-            Neerslag = "   ",
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
+            Precipitation = "   ",
         };
 
         // Act
@@ -401,8 +401,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                 = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             SurfaceWindDirectionDeg  = null,
             SurfaceWindSpeedKt       = null,
             // WindLevels is an empty list by default
@@ -424,8 +424,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                 = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             SurfaceWindDirectionDeg  = 270,
             SurfaceWindSpeedKt       = 15,
         };
@@ -445,8 +445,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                 = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             SurfaceWindDirectionDeg  = 270,
             SurfaceWindSpeedKt       = null,
         };
@@ -466,8 +466,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                 = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             SurfaceWindDirectionDeg  = null,
             SurfaceWindSpeedKt       = 15,
         };
@@ -488,8 +488,8 @@ public class PdfServiceOfpTests
         var sut = BuildSut();
         var fp = new FlightPreparation
         {
-            Datum                    = DateOnly.FromDateTime(DateTime.Today),
-            Tijdstip                 = new TimeOnly(9, 0),
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Time = new TimeOnly(9, 0),
             SurfaceWindDirectionDeg  = null,
             SurfaceWindSpeedKt       = null,
         };

--- a/src/FlightPrep.Tests/PdfServiceTests.cs
+++ b/src/FlightPrep.Tests/PdfServiceTests.cs
@@ -30,8 +30,8 @@ public class PdfServiceTests
 
     private static FlightPreparation MinimalFlight() => new()
     {
-        Datum    = DateOnly.FromDateTime(DateTime.Today),
-        Tijdstip = new TimeOnly(9, 0)
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Time = new TimeOnly(9, 0)
     };
 
     // ── Issue #33 tests ───────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ public class PdfServiceTests
         var fp  = MinimalFlight();
         // Give the flight data that would normally trigger red
         fp.SurfaceWindSpeedKt = 20;
-        fp.ZichtbaarheidKm    = 1;
+        fp.VisibilityKm    = 1;
         fp.CapeJkg            = 600;
 
         // Act

--- a/src/FlightPrep/Components/FlightMeteoSection.razor
+++ b/src/FlightPrep/Components/FlightMeteoSection.razor
@@ -73,19 +73,19 @@ else if (Fp.LocationId != null && Fp.LocationId != 0)
     </div>
     <div class="col-12">
         <label class="form-label">Windrichting/-snelheid per hoogte</label>
-        <textarea class="form-control" rows="3" @bind="Fp.WindPerHoogte"></textarea>
+        <textarea class="form-control" rows="3" @bind="Fp.WindByAltitude"></textarea>
     </div>
     <div class="col-md-6">
         <label class="form-label">Neerslagkans / bewolking</label>
-        <input type="text" class="form-control" @bind="Fp.Neerslag"/>
+        <input type="text" class="form-control" @bind="Fp.Precipitation"/>
     </div>
     <div class="col-md-2">
         <label class="form-label">Temperatuur (°C)</label>
-        <input type="number" step="0.1" class="form-control" @bind="Fp.TemperatuurC"/>
+        <input type="number" step="0.1" class="form-control" @bind="Fp.TemperatureC"/>
     </div>
     <div class="col-md-2">
         <label class="form-label">Dauwpunt (°C)</label>
-        <input type="number" step="0.1" class="form-control" @bind="Fp.DauwpuntC"/>
+        <input type="number" step="0.1" class="form-control" @bind="Fp.DewPointC"/>
     </div>
     <div class="col-md-2">
         <label class="form-label">QNH (hPa)</label>
@@ -93,7 +93,7 @@ else if (Fp.LocationId != null && Fp.LocationId != 0)
     </div>
     <div class="col-md-2">
         <label class="form-label">Zichtbaarheid (km)</label>
-        <input type="number" step="0.1" class="form-control" @bind="Fp.ZichtbaarheidKm"/>
+        <input type="number" step="0.1" class="form-control" @bind="Fp.VisibilityKm"/>
     </div>
     <div class="col-md-2">
         <label class="form-label">CAPE (J/kg)</label>

--- a/src/FlightPrep/Components/FlightMeteoSection.razor.cs
+++ b/src/FlightPrep/Components/FlightMeteoSection.razor.cs
@@ -119,7 +119,7 @@ public partial class FlightMeteoSection : ComponentBase
                 return;
             }
 
-            var flightDt = Fp.Datum.ToDateTime(Fp.Tijdstip);
+            var flightDt = Fp.Date.ToDateTime(Fp.Time);
             var levels = await WeatherFetchSvc.FetchWindProfileAsync(
                 Fp.Location.Latitude.Value, Fp.Location.Longitude.Value, flightDt);
             if (!levels.Any())

--- a/src/FlightPrep/Components/FlightPassengerList.Razor.cs
+++ b/src/FlightPrep/Components/FlightPassengerList.Razor.cs
@@ -43,7 +43,7 @@ public partial class FlightPassengerList:ComponentBase
     private bool CanCalculateLift =>
         Fp.Balloon is { VolumeM3: > 0, InternalEnvelopeTempC: >= 0 and <= 100 } &&
         Fp.Location?.ElevationM.HasValue == true &&
-        Fp is { TemperatuurC: not null, MaxAltitudeFt: not null } &&
+        Fp is { TemperatureC: not null, MaxAltitudeFt: not null } &&
         Fp.MaxAltitudeFt * 0.3048 > Fp.Location!.ElevationM;
 
     /// <summary>
@@ -55,7 +55,7 @@ public partial class FlightPassengerList:ComponentBase
         if (!CanCalculateLift) return;
         var a = Fp.MaxAltitudeFt!.Value * 0.3048;
         var eg = Fp.Location!.ElevationM!.Value;
-        var tg = Fp.TemperatuurC!.Value;
+        var tg = Fp.TemperatureC!.Value;
         var ti = Fp.Balloon!.InternalEnvelopeTempC!.Value;
         var v = Fp.Balloon!.VolumeM3!.Value;
         _liftResult = LiftCalculator.Calculate(a, eg, tg, ti, v);

--- a/src/FlightPrep/Components/FlightPassengerList.razor
+++ b/src/FlightPrep/Components/FlightPassengerList.razor
@@ -49,7 +49,7 @@
 {
     var altM = Fp.MaxAltitudeFt!.Value * 0.3048;
     var eg = Fp.Location!.ElevationM!.Value;
-    var tg = Fp.TemperatuurC!.Value;
+    var tg = Fp.TemperatureC!.Value;
     var ti = Fp.Balloon!.InternalEnvelopeTempC!.Value;
     var v = Fp.Balloon!.VolumeM3!.Value;
     <div class="alert alert-info py-2 mb-3 small">

--- a/src/FlightPrep/Components/Pages/FlightEdit.razor
+++ b/src/FlightPrep/Components/Pages/FlightEdit.razor
@@ -44,13 +44,13 @@
                         <div class="row g-3">
                             <div class="col-md-3">
                                 <label class="form-label">Datum</label>
-                                <input type="date" class="form-control" value="@_fp?.Datum.ToString("yyyy-MM-dd")"
-                                       @onchange="e => { var raw = e.Value?.ToString(); if (DateOnly.TryParse(raw, out var d)) { _fp!.Datum = d; UpdateSunriseSunset(); } }"/>
+                                <input type="date" class="form-control" value="@_fp?.Date.ToString("yyyy-MM-dd")"
+                                       @onchange="e => { var raw = e.Value?.ToString(); if (DateOnly.TryParse(raw, out var d)) { _fp!.Date = d; UpdateSunriseSunset(); } }"/>
                             </div>
                             <div class="col-md-3">
                                 <label class="form-label">Tijdstip (LT)</label>
-                                <input type="time" class="form-control" value="@_fp?.Tijdstip.ToString("HH:mm")"
-                                       @onchange="e => { var raw = e.Value?.ToString(); _fp!.Tijdstip = TimeOnly.TryParse(raw, out var t) ? t : _fp.Tijdstip; }"/>
+                                <input type="time" class="form-control" value="@_fp?.Time.ToString("HH:mm")"
+                                       @onchange="e => { var raw = e.Value?.ToString(); _fp!.Time = TimeOnly.TryParse(raw, out var t) ? t : _fp.Time; }"/>
                             </div>
                             <div class="col-md-3">
                                 <label class="form-label">Ballon</label>
@@ -88,7 +88,7 @@
                         </div>
                         <div class="mt-3">
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" @bind="_fp.VeldEigenaarGemeld"
+                                <input class="form-check-input" type="checkbox" @bind="_fp.FieldOwnerNotified"
                                        id="chkVeldEigenaar"/>
                                 <label class="form-check-label" for="chkVeldEigenaar">
                                     Veld eigenaar gemeld (indien van toepassing) –
@@ -149,15 +149,15 @@
                             </div>
                             <div class="col-12">
                                 <label class="form-label">Luchtruimstructuur</label>
-                                <textarea class="form-control" rows="3" @bind="_fp.Luchtruimstructuur"></textarea>
+                                <textarea class="form-control" rows="3" @bind="_fp.AirspaceStructure"></textarea>
                             </div>
                             <div class="col-12">
                                 <label class="form-label">Beperkingen / gesloten zones</label>
-                                <textarea class="form-control" rows="3" @bind="_fp.Beperkingen"></textarea>
+                                <textarea class="form-control" rows="3" @bind="_fp.Restrictions"></textarea>
                             </div>
                             <div class="col-12">
                                 <label class="form-label">Obstakels</label>
-                                <textarea class="form-control" rows="2" @bind="_fp.Obstakels"></textarea>
+                                <textarea class="form-control" rows="2" @bind="_fp.Obstacles"></textarea>
                             </div>
                         </div>
                     </div>
@@ -177,14 +177,14 @@
                         <div class="row g-3">
                             <div class="col-md-4">
                                 <label class="form-label">EHBO-kit en vuurblusser</label>
-                                <select class="form-select" @bind="_fp.EhboEnBlusser">
+                                <select class="form-select" @bind="_fp.FirstAidAndExtinguisher">
                                     <option value="JA">JA</option>
                                     <option value="NEE">NEE</option>
                                 </select>
                             </div>
                             <div class="col-md-4">
                                 <label class="form-label">Passagierslijst ingevuld</label>
-                                <select class="form-select" @bind="_fp.PassagierslijstIngevuld">
+                                <select class="form-select" @bind="_fp.PassengerListFilled">
                                     <option value="JA">JA</option>
                                     <option value="NEE">NEE</option>
                                     <option value="NVT">NVT</option>
@@ -192,7 +192,7 @@
                             </div>
                             <div class="col-md-4">
                                 <label class="form-label">Vluchtplan ingediend</label>
-                                <select class="form-select" @bind="_fp.VluchtplanIngediend">
+                                <select class="form-select" @bind="_fp.FlightPlanFiled">
                                     <option value="JA">JA</option>
                                     <option value="NEE">NEE</option>
                                     <option value="NVT">NVT</option>
@@ -214,25 +214,25 @@
                 <div id="sec5" class="accordion-collapse collapse">
                     <div class="accordion-body">
                         <div class="form-check mb-2">
-                            <input class="form-check-input" type="checkbox" @bind="_fp.BranderGetest" id="chk1"/>
+                            <input class="form-check-input" type="checkbox" @bind="_fp.BurnerTested" id="chk1"/>
                             <label class="form-check-label" for="chk1">Brander getest</label>
                         </div>
                         <div class="form-check mb-2">
-                            <input class="form-check-input" type="checkbox" @bind="_fp.GasflaconsGecontroleerd"
+                            <input class="form-check-input" type="checkbox" @bind="_fp.GasCylindersChecked"
                                    id="chk2"/>
                             <label class="form-check-label" for="chk2">Gasflessen gevuld &amp; gecontroleerd</label>
                         </div>
                         <div class="form-check mb-2">
-                            <input class="form-check-input" type="checkbox" @bind="_fp.BallonVisueel" id="chk3"/>
+                            <input class="form-check-input" type="checkbox" @bind="_fp.BalloonVisual" id="chk3"/>
                             <label class="form-check-label" for="chk3">Ballon en mand visueel geïnspecteerd</label>
                         </div>
                         <div class="form-check mb-2">
-                            <input class="form-check-input" type="checkbox" @bind="_fp.VerankeringenGecontroleerd"
+                            <input class="form-check-input" type="checkbox" @bind="_fp.MooringsChecked"
                                    id="chk4"/>
                             <label class="form-check-label" for="chk4">Verankeringen en touwen gecontroleerd</label>
                         </div>
                         <div class="form-check mb-2">
-                            <input class="form-check-input" type="checkbox" @bind="_fp.InstrumentenWerkend" id="chk5"/>
+                            <input class="form-check-input" type="checkbox" @bind="_fp.InstrumentsWorking" id="chk5"/>
                             <label class="form-check-label" for="chk5">Instrumenten werkend</label>
                         </div>
                     </div>
@@ -471,7 +471,7 @@
                         <div class="mb-3 mt-3">
                             <label class="form-label">Trajectnotities / waypoints</label>
                             <textarea class="form-control" rows="4" placeholder="Trajectnotities / waypoints..."
-                                      @bind="_fp!.Traject"></textarea>
+                                      @bind="_fp!.Route"></textarea>
                         </div>
 
                         <!-- Image upload – Traject -->
@@ -496,7 +496,7 @@
                     <div class="accordion-body">
                         <textarea class="form-control font-monospace" rows="15"
                                   placeholder="Plak hier de Skeyes ballonbulletin tekst..."
-                                  @bind="_fp.Ballonbulletin"></textarea>
+                                  @bind="_fp.BalloonBulletin"></textarea>
                     </div>
                 </div>
             </div>

--- a/src/FlightPrep/Components/Pages/FlightEdit.razor.cs
+++ b/src/FlightPrep/Components/Pages/FlightEdit.razor.cs
@@ -291,7 +291,7 @@ public partial class FlightEdit(
         StateHasChanged();
         try
         {
-            var launchUtc = DateTime.SpecifyKind(_fp.Datum.ToDateTime(_fp.Tijdstip), DateTimeKind.Utc);
+            var launchUtc = DateTime.SpecifyKind(_fp.Date.ToDateTime(_fp.Time), DateTimeKind.Utc);
             _enhancedTrajectories = await enhancedTrajectorySvc.ComputeMultipleAsync(
                 _fp.Location.Latitude.Value,
                 _fp.Location.Longitude.Value,
@@ -344,8 +344,8 @@ public partial class FlightEdit(
     {
         if (_fp == null) return;
         var loc = _locations.FirstOrDefault(l => l.Id == _fp.LocationId);
-        if (loc?.AirspaceNotes != null && string.IsNullOrWhiteSpace(_fp.Luchtruimstructuur))
-            _fp.Luchtruimstructuur = loc.AirspaceNotes;
+        if (loc?.AirspaceNotes != null && string.IsNullOrWhiteSpace(_fp.AirspaceStructure))
+            _fp.AirspaceStructure = loc.AirspaceNotes;
         UpdateCurrentLocation();
         UpdateSunriseSunset();
     }
@@ -360,7 +360,7 @@ public partial class FlightEdit(
         if (_fp == null) { _sunriseSunset = null; return; }
         var loc = _locations.FirstOrDefault(l => l.Id == _fp.LocationId);
         if (loc?.Latitude.HasValue == true && loc.Longitude.HasValue)
-            _sunriseSunset = sunriseSvc.Calculate(_fp.Datum, loc.Latitude!.Value, loc.Longitude!.Value);
+            _sunriseSunset = sunriseSvc.Calculate(_fp.Date, loc.Latitude!.Value, loc.Longitude!.Value);
         else
             _sunriseSunset = null;
     }
@@ -431,7 +431,7 @@ public partial class FlightEdit(
         {
             var pdfBytes = await pdfSvc.GenerateAsync(saved, userId: _userId);
             await js.InvokeVoidAsync("downloadFileFromBytes",
-                $"vaartvoorbereiding_{saved.Datum:yyyy-MM-dd}_{saved.Id}.pdf",
+                $"vaartvoorbereiding_{saved.Date:yyyy-MM-dd}_{saved.Id}.pdf",
                 "application/pdf", Convert.ToBase64String(pdfBytes));
         }
         catch (Exception ex) { _saveMessage = $"❌ PDF fout: {ex.Message}"; _saveError = true; }

--- a/src/FlightPrep/Components/Pages/FlightList.razor
+++ b/src/FlightPrep/Components/Pages/FlightList.razor
@@ -77,8 +77,8 @@ else
             @foreach (var f in _flights!)
             {
                 <tr>
-                    <td class="fw-semibold">@f.Datum.ToString("dd/MM/yyyy")</td>
-                    <td>@f.Tijdstip.ToString("HH:mm")</td>
+                    <td class="fw-semibold">@f.Date.ToString("dd/MM/yyyy")</td>
+                    <td>@f.Time.ToString("HH:mm")</td>
                     <td>@(f.BalloonRegistration ?? "–")</td>
                     <td>@(f.PilotName ?? "–")</td>
                     <td>@(f.LocationName ?? "–")</td>

--- a/src/FlightPrep/Components/Pages/FlightList.razor.cs
+++ b/src/FlightPrep/Components/Pages/FlightList.razor.cs
@@ -42,7 +42,7 @@ public partial class FlightList : ComponentBase
     protected override async Task OnInitializedAsync() => await LoadFlights();
 
     private string GetGoNoGo(FlightPreparationSummary f) =>
-        GoNoGoSvc.Compute(f.SurfaceWindSpeedKt, f.ZichtbaarheidKm, f.CapeJkg, _goNoGoSettings);
+        GoNoGoSvc.Compute(f.SurfaceWindSpeedKt, f.VisibilityKm, f.CapeJkg, _goNoGoSettings);
 
     private async Task LoadFlights()
     {

--- a/src/FlightPrep/Components/Pages/FlightView.razor
+++ b/src/FlightPrep/Components/Pages/FlightView.razor
@@ -42,8 +42,8 @@ else
         <div class="fp-page-header">
             <div>
                 <h2 class="mb-1">
-                    @_fp.Datum.ToString("dd MMMM yyyy") &nbsp;
-                    <span class="text-muted fw-normal fs-5">@_fp.Tijdstip.ToString("HH:mm")</span>
+                    @_fp.Date.ToString("dd MMMM yyyy") &nbsp;
+                    <span class="text-muted fw-normal fs-5">@_fp.Time.ToString("HH:mm")</span>
                 </h2>
                 @{ var gng = _assessment?.GoNoGo ?? "unknown"; }
                 <FlightGoNoGoBadge GoNoGoResult="@gng" ShowEmoji="true"/>
@@ -74,9 +74,9 @@ else
                     <div class="card-body">
                         <dl class="row mb-0">
                             <dt class="col-sm-3">Datum</dt>
-                            <dd class="col-sm-9">@_fp.Datum.ToString("dd/MM/yyyy")</dd>
+                            <dd class="col-sm-9">@_fp.Date.ToString("dd/MM/yyyy")</dd>
                             <dt class="col-sm-3">Tijdstip</dt>
-                            <dd class="col-sm-9">@_fp.Tijdstip.ToString("HH:mm") LT</dd>
+                            <dd class="col-sm-9">@_fp.Time.ToString("HH:mm") LT</dd>
                             <dt class="col-sm-3">Ballon</dt>
                             <dd class="col-sm-9">@(_fp.Balloon != null ? $"{_fp.Balloon.Registration} – {_fp.Balloon.Type} ({(_fp.Balloon.VolumeM3.HasValue ? $"{_fp.Balloon.VolumeM3:F0} m³" : "–")})" : "–")</dd>
                             <dt class="col-sm-3">Piloot / PIC</dt>
@@ -85,7 +85,7 @@ else
                             <dd class="col-sm-9">@(_fp.Location?.Name ?? "–")</dd>
                             <dt class="col-sm-3">Veld eigenaar gemeld</dt>
                             <dd class="col-sm-9">
-                                @if (_fp.VeldEigenaarGemeld)
+                                @if (_fp.FieldOwnerNotified)
                                 {
                                     <span class="badge bg-success">Ja</span>
                                 }
@@ -119,21 +119,21 @@ else
                             <dt class="col-sm-3">TAF</dt>
                             <dd class="col-sm-9 font-monospace" style="white-space:pre-wrap">@(_fp.Taf ?? "–")</dd>
                             <dt class="col-sm-3">Wind per hoogte</dt>
-                            <dd class="col-sm-9" style="white-space:pre-wrap">@(_fp.WindPerHoogte ?? "–")</dd>
+                            <dd class="col-sm-9" style="white-space:pre-wrap">@(_fp.WindByAltitude ?? "–")</dd>
                             <dt class="col-sm-3">Neerslag / bewolking</dt>
-                            <dd class="col-sm-9">@(_fp.Neerslag ?? "–")</dd>
+                            <dd class="col-sm-9">@(_fp.Precipitation ?? "–")</dd>
                             <dt class="col-sm-3">Windrichting oppervlak</dt>
                             <dd class="col-sm-9">@(_fp.SurfaceWindDirectionDeg.HasValue ? $"{_fp.SurfaceWindDirectionDeg}°" : "–")</dd>
                             <dt class="col-sm-3">Windsnelheid oppervlak</dt>
                             <dd class="col-sm-9">@(_fp.SurfaceWindSpeedKt.HasValue ? $"{_fp.SurfaceWindSpeedKt} kt" : "–")</dd>
                             <dt class="col-sm-3">Temperatuur</dt>
-                            <dd class="col-sm-9">@(_fp.TemperatuurC.HasValue ? $"{_fp.TemperatuurC}°C" : "–")</dd>
+                            <dd class="col-sm-9">@(_fp.TemperatureC.HasValue ? $"{_fp.TemperatureC}°C" : "–")</dd>
                             <dt class="col-sm-3">Dauwpunt</dt>
-                            <dd class="col-sm-9">@(_fp.DauwpuntC.HasValue ? $"{_fp.DauwpuntC}°C" : "–")</dd>
+                            <dd class="col-sm-9">@(_fp.DewPointC.HasValue ? $"{_fp.DewPointC}°C" : "–")</dd>
                             <dt class="col-sm-3">QNH</dt>
                             <dd class="col-sm-9">@(_fp.QnhHpa.HasValue ? $"{_fp.QnhHpa} hPa" : "–")</dd>
                             <dt class="col-sm-3">Zichtbaarheid</dt>
-                            <dd class="col-sm-9">@(_fp.ZichtbaarheidKm.HasValue ? $"{_fp.ZichtbaarheidKm} km" : "–")</dd>
+                            <dd class="col-sm-9">@(_fp.VisibilityKm.HasValue ? $"{_fp.VisibilityKm} km" : "–")</dd>
                             <dt class="col-sm-3">CAPE</dt>
                             <dd class="col-sm-9">@(_fp.CapeJkg.HasValue ? $"{_fp.CapeJkg} J/kg" : "–")</dd>
                         </dl>
@@ -187,11 +187,11 @@ else
                             <dt class="col-sm-5">NOTAMs gecontroleerd</dt>
                             <dd class="col-sm-7">@_fp.NotamsGecontroleerd</dd>
                             <dt class="col-sm-5">Luchtruimstructuur</dt>
-                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.Luchtruimstructuur ?? "–")</dd>
+                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.AirspaceStructure ?? "–")</dd>
                             <dt class="col-sm-5">Beperkingen</dt>
-                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.Beperkingen ?? "–")</dd>
+                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.Restrictions ?? "–")</dd>
                             <dt class="col-sm-5">Obstakels</dt>
-                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.Obstakels ?? "–")</dd>
+                            <dd class="col-sm-7" style="white-space:pre-wrap">@(_fp.Obstacles ?? "–")</dd>
                         </dl>
                     </div>
                 </div>
@@ -204,11 +204,11 @@ else
                     <div class="card-body">
                         <dl class="row mb-0">
                             <dt class="col-sm-7">EHBO-kit en vuurblusser</dt>
-                            <dd class="col-sm-5">@_fp.EhboEnBlusser</dd>
+                            <dd class="col-sm-5">@_fp.FirstAidAndExtinguisher</dd>
                             <dt class="col-sm-7">Passagierslijst ingevuld</dt>
-                            <dd class="col-sm-5">@_fp.PassagierslijstIngevuld</dd>
+                            <dd class="col-sm-5">@_fp.PassengerListFilled</dd>
                             <dt class="col-sm-7">Vluchtplan ingediend</dt>
-                            <dd class="col-sm-5">@_fp.VluchtplanIngediend</dd>
+                            <dd class="col-sm-5">@_fp.FlightPlanFiled</dd>
                         </dl>
                     </div>
                 </div>
@@ -220,11 +220,11 @@ else
                     <div class="card-header bg-primary text-white">5. Technische Controle</div>
                     <div class="card-body">
                         <ul class="list-unstyled mb-0">
-                            <li>@(_fp.BranderGetest ? "☑" : "☐") Brander getest</li>
-                            <li>@(_fp.GasflaconsGecontroleerd ? "☑" : "☐") Gasflessen gevuld &amp; gecontroleerd</li>
-                            <li>@(_fp.BallonVisueel ? "☑" : "☐") Ballon en mand visueel geïnspecteerd</li>
-                            <li>@(_fp.VerankeringenGecontroleerd ? "☑" : "☐") Verankeringen en touwen gecontroleerd</li>
-                            <li>@(_fp.InstrumentenWerkend ? "☑" : "☐") Instrumenten werkend</li>
+                            <li>@(_fp.BurnerTested ? "☑" : "☐") Brander getest</li>
+                            <li>@(_fp.GasCylindersChecked ? "☑" : "☐") Gasflessen gevuld &amp; gecontroleerd</li>
+                            <li>@(_fp.BalloonVisual ? "☑" : "☐") Ballon en mand visueel geïnspecteerd</li>
+                            <li>@(_fp.MooringsChecked ? "☑" : "☐") Verankeringen en touwen gecontroleerd</li>
+                            <li>@(_fp.InstrumentsWorking ? "☑" : "☐") Instrumenten werkend</li>
                         </ul>
                     </div>
                 </div>
@@ -325,9 +325,9 @@ else
                                      style="height:400px;border-radius:8px;overflow:hidden;"></div>
                             </div>
                         }
-                        @if (!string.IsNullOrWhiteSpace(_fp?.Traject))
+                        @if (!string.IsNullOrWhiteSpace(_fp?.Route))
                         {
-                            <pre class="mb-3">@_fp.Traject</pre>
+                            <pre class="mb-3">@_fp.Route</pre>
                         }
                         @{ var traj = _fp?.Images.Where(i => i.Section == "Traject").ToList(); }
                         @if (traj is { Count: > 0 })
@@ -342,7 +342,7 @@ else
                                 }
                             </div>
                         }
-                        @if (string.IsNullOrWhiteSpace(_fp?.Traject) && traj is { Count: 0 })
+                        @if (string.IsNullOrWhiteSpace(_fp?.Route) && traj is { Count: 0 })
                         {
                             <span class="text-muted">–</span>
                         }
@@ -355,7 +355,7 @@ else
                 <div class="card">
                     <div class="card-header bg-primary text-white">9. Ballonbulletin</div>
                     <div class="card-body">
-                        <pre class="font-monospace small mb-0">@_fp?.Ballonbulletin</pre>
+                        <pre class="font-monospace small mb-0">@_fp?.BalloonBulletin</pre>
                     </div>
                 </div>
             </div>

--- a/src/FlightPrep/Components/Pages/FlightView.razor.cs
+++ b/src/FlightPrep/Components/Pages/FlightView.razor.cs
@@ -101,7 +101,7 @@ public partial class FlightView:ComponentBase
             // Sunrise/sunset
             var loc = _fp.Location;
             if (loc?.Latitude.HasValue == true && loc.Longitude.HasValue)
-                _sunriseSunset = SunriseSvc.Calculate(_fp.Datum, loc.Latitude!.Value, loc.Longitude!.Value);
+                _sunriseSunset = SunriseSvc.Calculate(_fp.Date, loc.Latitude!.Value, loc.Longitude!.Value);
 
             LoadExistingTrack();
 
@@ -267,7 +267,7 @@ public partial class FlightView:ComponentBase
     {
         if (_fp == null) return;
         var pdfBytes = await PdfSvc.GenerateAsync(_fp, userId: _userId);
-        var fileName = $"vaartvoorbereiding_{_fp.Datum:yyyy-MM-dd}_{_fp.Id}.pdf";
+        var fileName = $"vaartvoorbereiding_{_fp.Date:yyyy-MM-dd}_{_fp.Id}.pdf";
         await Js.InvokeVoidAsync("downloadFileFromBytes", fileName, "application/pdf",
             Convert.ToBase64String(pdfBytes));
     }
@@ -277,7 +277,7 @@ public partial class FlightView:ComponentBase
         if (_fp == null) return;
         var settings = await OfpSettingsSvc.GetSettingsAsync(_userId);
         var pdfBytes = await PdfSvc.GenerateOfpAsync(_fp, settings.PassengerEquipmentWeightKg);
-        var fileName = $"OFP_{_fp.Datum:yyyy-MM-dd}_{_fp.Id}.pdf";
+        var fileName = $"OFP_{_fp.Date:yyyy-MM-dd}_{_fp.Id}.pdf";
         await Js.InvokeVoidAsync("downloadFileFromBytes", fileName, "application/pdf",
             Convert.ToBase64String(pdfBytes));
     }

--- a/src/FlightPrep/Components/Pages/Home.razor
+++ b/src/FlightPrep/Components/Pages/Home.razor
@@ -72,7 +72,7 @@
                         <div class="d-flex justify-content-between align-items-center">
                             <div>
                                 <div class="fw-semibold">
-                                    @f.Datum.ToString("dd/MM/yyyy") @f.Tijdstip.ToString("HH:mm")
+                                    @f.Date.ToString("dd/MM/yyyy") @f.Time.ToString("HH:mm")
                                     @if (isShared)
                                     {
                                         <span class="badge bg-info text-dark ms-2 small">Gedeeld</span>

--- a/src/FlightPrep/Components/Pages/Logboek.razor
+++ b/src/FlightPrep/Components/Pages/Logboek.razor
@@ -18,8 +18,8 @@ else
             <h2 class="mb-1">📓 Logboek</h2>
             @if (_flights.Count > 0)
             {
-                var first = _flights.First().Datum;
-                var last = _flights.Last().Datum;
+                var first = _flights.First().Date;
+                var last = _flights.Last().Date;
                 <p class="text-muted mb-0">@first.ToString("dd/MM/yyyy") – @last.ToString("dd/MM/yyyy")</p>
             }
             else
@@ -127,10 +127,10 @@ else
                     </tr>
                     </thead>
                     <tbody>
-                    @foreach (var f in _flights.OrderByDescending(f => f.Datum).ThenByDescending(f => f.Tijdstip))
+                    @foreach (var f in _flights.OrderByDescending(f => f.Date).ThenByDescending(f => f.Time))
                     {
                         <tr style="cursor:pointer" @onclick="() => Nav(f.Id)">
-                            <td>@f.Datum.ToString("dd/MM/yyyy")</td>
+                            <td>@f.Date.ToString("dd/MM/yyyy")</td>
                             <td>@(f.Location?.Name ?? "–")</td>
                             <td>@(f.Balloon?.Registration ?? "–")</td>
                             <td>@(f.Pilot?.Name ?? "–")</td>

--- a/src/FlightPrep/Components/Pages/Logboek.razor.cs
+++ b/src/FlightPrep/Components/Pages/Logboek.razor.cs
@@ -49,7 +49,7 @@ public partial class Logboek : ComponentBase
             .FirstOrDefault();
 
         _flightsByMonth = _flights
-            .GroupBy(f => new { f.Datum.Year, f.Datum.Month })
+            .GroupBy(f => new { f.Date.Year, f.Date.Month })
             .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.Month)
             .Select(g => ($"{g.Key.Year}-{g.Key.Month:D2}", g.Count()))
             .ToList();

--- a/src/FlightPrep/Services/FlightAssessmentService.cs
+++ b/src/FlightPrep/Services/FlightAssessmentService.cs
@@ -30,7 +30,7 @@ public class FlightAssessmentService(IGoNoGoService goNoGoSvc) : IFlightAssessme
 
         var goNoGo = goNoGoSvc.Compute(
             fp.SurfaceWindSpeedKt,
-            fp.ZichtbaarheidKm,
+            fp.VisibilityKm,
             fp.CapeJkg,
             settings);
 
@@ -54,7 +54,7 @@ public class FlightAssessmentService(IGoNoGoService goNoGoSvc) : IFlightAssessme
 
         var goNoGo = goNoGoSvc.Compute(
             fp.SurfaceWindSpeedKt,
-            fp.ZichtbaarheidKm,
+            fp.VisibilityKm,
             fp.CapeJkg,
             settings);
 

--- a/src/FlightPrep/Services/FlightPreparationService.cs
+++ b/src/FlightPrep/Services/FlightPreparationService.cs
@@ -67,7 +67,7 @@ public class FlightPreparationService(
             .Include(f => f.Pilot)
             .Include(f => f.Location)
             .Include(f => f.Shares)
-            .OrderByDescending(f => f.Datum).ThenByDescending(f => f.Tijdstip)
+            .OrderByDescending(f => f.Date).ThenByDescending(f => f.Time)
             .ToListAsync();
 
         // Step 2: Batch-load owner usernames in a single round-trip.
@@ -89,14 +89,14 @@ public class FlightPreparationService(
             var isShared = !isAdmin && f.CreatedByUserId != userId;
             return new FlightPreparationSummary(
                 f.Id,
-                f.Datum,
-                f.Tijdstip,
+                f.Date,
+                f.Time,
                 f.IsFlown,
                 f.Balloon?.Registration,
                 f.Pilot?.Name,
                 f.Location?.Name,
                 f.SurfaceWindSpeedKt,
-                f.ZichtbaarheidKm,
+                f.VisibilityKm,
                 f.CapeJkg,
                 f.CreatedByUserId)
             {
@@ -144,8 +144,8 @@ public class FlightPreparationService(
         var total = await query.CountAsync();
 
         var ordered = sortDescending
-            ? query.OrderByDescending(f => f.Datum).ThenByDescending(f => f.Tijdstip)
-            : query.OrderBy(f => f.Datum).ThenBy(f => f.Tijdstip);
+            ? query.OrderByDescending(f => f.Date).ThenByDescending(f => f.Time)
+            : query.OrderBy(f => f.Date).ThenBy(f => f.Time);
 
         // Step 1: Load paged flights with navigation properties — no correlated subquery.
         var flights = await ordered
@@ -177,14 +177,14 @@ public class FlightPreparationService(
             var isShared = !isAdmin && f.CreatedByUserId != userId;
             return new FlightPreparationSummary(
                 f.Id,
-                f.Datum,
-                f.Tijdstip,
+                f.Date,
+                f.Time,
                 f.IsFlown,
                 f.Balloon?.Registration,
                 f.Pilot?.Name,
                 f.Location?.Name,
                 f.SurfaceWindSpeedKt,
-                f.ZichtbaarheidKm,
+                f.VisibilityKm,
                 f.CapeJkg,
                 f.CreatedByUserId)
             {
@@ -632,7 +632,7 @@ public class FlightPreparationService(
             return (0, 0, 0);
 
         var total = await query.CountAsync();
-        var thisYear = await query.CountAsync(f => f.Datum.Year == currentYear);
+        var thisYear = await query.CountAsync(f => f.Date.Year == currentYear);
         var flown = await query.CountAsync(f => f.IsFlown);
         return (total, thisYear, flown);
     }
@@ -664,8 +664,8 @@ public class FlightPreparationService(
 
         return await query
             .AsNoTracking()
-            .OrderByDescending(f => f.Datum)
-            .ThenByDescending(f => f.Tijdstip)
+            .OrderByDescending(f => f.Date)
+            .ThenByDescending(f => f.Time)
             .Take(count)
             .ToListAsync();
     }
@@ -698,7 +698,7 @@ public class FlightPreparationService(
 
         return await query
             .AsNoTracking()
-            .OrderBy(f => f.Datum)
+            .OrderBy(f => f.Date)
             .ToListAsync();
     }
 }

--- a/src/FlightPrep/Services/GoNoGoService.cs
+++ b/src/FlightPrep/Services/GoNoGoService.cs
@@ -39,7 +39,7 @@ public class GoNoGoService(IDbContextFactory<AppDbContext> dbFactory) : IGoNoGoS
         await db.SaveChangesAsync();
     }
 
-    public string Compute(FlightPreparation fp, GoNoGoSettings s) => Compute(fp.SurfaceWindSpeedKt, fp.ZichtbaarheidKm, fp.CapeJkg, s);
+    public string Compute(FlightPreparation fp, GoNoGoSettings s) => Compute(fp.SurfaceWindSpeedKt, fp.VisibilityKm, fp.CapeJkg, s);
 
     /// <summary>
     ///     Compute overload that accepts raw weather values — used by the list page


### PR DESCRIPTION
## Summary

Closes #34

Renames all 21 Dutch-named C# properties in `FlightPreparation` (and related types) to English equivalents. PostgreSQL column names are preserved unchanged via `[Column("DutchName")]` attributes — **no EF migration required**.

## Rename map

| Dutch | English | Column preserved |
|---|---|---|
| `Datum` | `Date` | `Datum` |
| `Tijdstip` | `Time` | `Tijdstip` |
| `Neerslag` | `Precipitation` | `Neerslag` |
| `TemperatuurC` | `TemperatureC` | `TemperatuurC` |
| `DauwpuntC` | `DewPointC` | `DauwpuntC` |
| `ZichtbaarheidKm` | `VisibilityKm` | `ZichtbaarheidKm` |
| `Luchtruimstructuur` | `AirspaceStructure` | `Luchtruimstructuur` |
| `Beperkingen` | `Restrictions` | `Beperkingen` |
| `Obstakels` | `Obstacles` | `Obstakels` |
| `EhboEnBlusser` | `FirstAidAndExtinguisher` | `EhboEnBlusser` |
| `PassagierslijstIngevuld` | `PassengerListFilled` | `PassagierslijstIngevuld` |
| `VluchtplanIngediend` | `FlightPlanFiled` | `VluchtplanIngediend` |
| `BranderGetest` | `BurnerTested` | `BranderGetest` |
| `GasflaconsGecontroleerd` | `GasCylindersChecked` | `GasflaconsGecontroleerd` |
| `BallonVisueel` | `BalloonVisual` | `BallonVisueel` |
| `VerankeringenGecontroleerd` | `MooringsChecked` | `VerankeringenGecontroleerd` |
| `InstrumentenWerkend` | `InstrumentsWorking` | `InstrumentenWerkend` |
| `Traject` | `Route` | `Traject` |
| `Ballonbulletin` | `BalloonBulletin` | `Ballonbulletin` |
| `VeldEigenaarGemeld` | `FieldOwnerNotified` | `VeldEigenaarGemeld` |
| `WindPerHoogte` | `WindByAltitude` | `WindPerHoogte` |

## Scope
- Models, services, Razor components/pages, tests (34 files total)
- `FlightPreparationSummary` record params also renamed (`Date`, `Time`, `VisibilityKm`)
- No migration — DB schema unchanged

## Tests
27 new tests (462 total) including reflection-based checks that verify every `[Column]` attribute matches the original Dutch column name — catches any future accidental removal before it breaks production.